### PR TITLE
Fix invalid hover background color

### DIFF
--- a/src/app/passwords/new/page.tsx
+++ b/src/app/passwords/new/page.tsx
@@ -116,7 +116,7 @@ const AddPassword: React.FC = () => {
                         onChange={handleChange}
                     ></textarea>
                 </div>
-                <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg--600">登録</button>
+                <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">登録</button>
             </form>
         </div>
     );


### PR DESCRIPTION
## Summary
- fix incorrect `hover:bg--600` class in the password creation page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ba8d98388332bf0eb29b2b72e60c