### PR TITLE
Fix edit page param handling

### DIFF
--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -14,9 +14,9 @@ type Password = {
   memo: string | null;
 };
 
-const UpdatePasswordPage = ({ params }: { params: Promise<{ id: string }> }) => {
+const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
   const router = useRouter();
-  const [id, setId] = useState<string | null>(null);
+  const [id] = useState<string>(params.id);
   const [siteName, setSiteName] = useState('');
   const [category, setCategory] = useState('');
   const [siteUrl, setSiteUrl] = useState('');
@@ -29,16 +29,6 @@ const UpdatePasswordPage = ({ params }: { params: Promise<{ id: string }> }) => 
   const [error, setError] = useState<string | null>(null);
 
   const [loading, setLoading] = useState(true);
-
-  // paramsをアンラップしてIDを取得
-  useEffect(() => {
-    const fetchParams = async () => {
-      const resolvedParams = await params;
-      setId(resolvedParams.id);
-    };
-
-    fetchParams();
-  }, [params]);
 
   // IDが取得できたらパスワードデータを取得
   useEffect(() => {


### PR DESCRIPTION
## Summary
- refactor edit password page to accept `params` directly and use `params.id` without an effect

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8b93a4883328e59fb9e5bf62bda