### PR TITLE
Fix button hover color

### DIFF
--- a/src/app/passwords/new/page.tsx
+++ b/src/app/passwords/new/page.tsx
@@ -116,7 +116,7 @@ const AddPassword: React.FC = () => {
                         onChange={handleChange}
                     ></textarea>
                 </div>
-                <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg--600">登録</button>
+                <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">登録</button>
             </form>
         </div>
     );


### PR DESCRIPTION
## Summary
- fix incorrect Tailwind class `hover:bg--600` in password form

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f98c6a288332a25c69a0b618168a