### PR TITLE
Refactor Password type imports

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -3,16 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import PasswordList from '../components/PasswordList';
-
-type Password = {
-  id: number;
-  site_name: string;
-  site_url: string;
-  login_id: string | null;
-  password: string;
-  email: string | null;
-  category: string | null;
-};
+import type { Password } from '@/types/password';
 
 const MainPage = () => {
   const [passwords, setPasswords] = useState<Password[]>([]);

--- a/src/app/api/passwords/[id]/route.ts
+++ b/src/app/api/passwords/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { runGet, runExecute } from '../../../../lib/db';
-import type { Password } from '../../../../types/password';
+import type { Password } from '@/types/password';
 
 
 // GET: 特定のパスワード情報を取得

--- a/src/app/api/passwords/route.ts
+++ b/src/app/api/passwords/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/passwords/route.ts
 import { NextResponse } from 'next/server';
 import { runSelect, runExecute } from '@/lib/db';
-import type { Password } from '../../../types/password';
+import type { Password } from '@/types/password';
 
 export async function GET() {
   try {

--- a/src/app/components/PasswordList.tsx
+++ b/src/app/components/PasswordList.tsx
@@ -2,16 +2,7 @@
 
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
-
-type Password = {
-    id: number;
-    site_name: string;
-    site_url: string;
-    login_id: string | null;
-    password: string;
-    email: string | null;
-    category: string | null;
-};
+import type { Password } from '@/types/password';
 
 type PasswordListProps = {
     passwords: Password[];

--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -2,17 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-
-type Password = {
-  id: number;
-  category: string | null;
-  site_name: string;
-  site_url: string;
-  login_id: string | null;
-  password: string;
-  email: string | null;
-  memo: string | null;
-};
+import type { Password } from '@/types/password';
 
 const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- import `Password` from `@/types/password`
- remove duplicate `Password` type definitions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa9c49ac833281b80b0bde02c644