### PR TITLE
Add Jest setup and API tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,14 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",
@@ -23,6 +24,8 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29",
+    "supertest": "^6"
   }
 }

--- a/tests/api/passwords.test.ts
+++ b/tests/api/passwords.test.ts
@@ -1,0 +1,58 @@
+import { GET, POST } from '../../src/app/api/passwords/route';
+import { runSelect, runExecute } from '../../src/lib/db';
+
+// Helper to create Request object for POST
+function createPostRequest(body: any) {
+  return new Request('http://localhost/api/passwords', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/passwords', () => {
+  it('should return list of passwords', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+describe('POST /api/passwords', () => {
+  const testEntry = {
+    category: 'Test',
+    site_name: 'jest-site',
+    site_url: 'https://jest.example.com',
+    login_id: 'jest',
+    password: 'secret',
+    email: 'jest@example.com',
+    memo: 'jest memo',
+  };
+
+  afterAll(() => {
+    runExecute('DELETE FROM password_manager WHERE site_name = ?', [
+      testEntry.site_name,
+    ]);
+  });
+
+  it('should create a new password entry', async () => {
+    const req = createPostRequest(testEntry);
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ message: '登録成功' });
+
+    const rows = runSelect(
+      'SELECT * FROM password_manager WHERE site_name = ?',
+      [testEntry.site_name]
+    );
+    expect(rows.length).toBe(1);
+  });
+
+  it('should return 400 when required fields missing', async () => {
+    const req = createPostRequest({});
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and supertest devDependencies and `npm test` script
- configure Jest for Next.js using next/jest
- add tests for GET/POST password API routes

## Testing
- `npm test` *(fails: jest command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fbf4fc4c8332ae551b73d204f2d7