### PR TITLE
Add wiki creation 

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -11,8 +11,13 @@ db.exec(`
     memo TEXT,
     category TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+  CREATE TABLE IF NOT EXISTS wiki (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
 `);
-
-console.log('パスワード管理テーブルを作成しました');
+console.log('パスワード管理テーブルとwikiテーブルを作成しました');

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -3,10 +3,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import PasswordList from '../components/PasswordList';
+import WikiCards from '../components/WikiCards';
 import type { Password } from '@/types/password';
+import type { Wiki } from '@/types/wiki';
 
 const MainPage = () => {
   const [passwords, setPasswords] = useState<Password[]>([]);
+  const [wikis, setWikis] = useState<Wiki[]>([]);
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState<{ diaries?: string; wikis?: string; passwords?: string }>({});
 
@@ -30,6 +33,7 @@ const MainPage = () => {
     const loadData = async () => {
       await Promise.all([
         fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
+        fetchData<Wiki[]>('/api/wiki?limit=3', setWikis, 'wikis'),
       ]);
       setLoading(false);
     };
@@ -46,6 +50,12 @@ const MainPage = () => {
         <h1 className="text-2xl font-bold">パスワード管理</h1>
         <div className="flex space-x-4">
           <Link
+            href="/wikis/new"
+            className="bg-blue-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-blue-600 active:scale-95 transition-transform"
+          >
+            Wiki登録
+          </Link>
+          <Link
             href="/passwords/new"
             className="bg-green-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-green-600 active:scale-95 transition-transform"
           >
@@ -53,6 +63,21 @@ const MainPage = () => {
           </Link>
         </div>
       </header>
+      <section className="my-6">
+        <h2 className="text-xl font-semibold">最新Wiki</h2>
+        {errors.wikis ? (
+          <p className="text-red-500">{errors.wikis}</p>
+        ) : wikis.length > 0 ? (
+          <WikiCards wikis={wikis} />
+        ) : (
+          <p className="text-gray-500">登録されたWikiがありません。</p>
+        )}
+        <div className="mt-2">
+          <Link href="/wikis" className="text-blue-600 hover:underline">
+            一覧を見る
+          </Link>
+        </div>
+      </section>
       <section className="my-6">
         <h2 className="text-xl font-semibold">パスワード一覧</h2>
         {errors.passwords ? (

--- a/src/app/api/wiki/[id]/route.ts
+++ b/src/app/api/wiki/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Wiki } from '@/types/wiki';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid wiki ID.' }, { status: 400 });
+  }
+  try {
+    const result = runGet<Wiki>('SELECT * FROM wiki WHERE id = ?', [Number(id)]);
+    if (!result) {
+      return NextResponse.json({ error: 'wiki entry not found.' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch wiki entry.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { title, content } = body;
+    if (!title || !content) {
+      return NextResponse.json({ error: 'title and content are required.' }, { status: 400 });
+    }
+    runExecute('UPDATE wiki SET title = ?, content = ? WHERE id = ?', [title, content, Number(id)]);
+    return NextResponse.json({ message: 'wiki entry updated successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to update wiki entry.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM wiki WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'wiki entry deleted successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete wiki entry.' }, { status: 500 });
+  }
+}

--- a/src/app/api/wiki/route.ts
+++ b/src/app/api/wiki/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { runSelect, runExecute } from '@/lib/db';
+import type { Wiki } from '@/types/wiki';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit');
+  try {
+    const sql = limit
+      ? `SELECT * FROM wiki ORDER BY id DESC LIMIT ?`
+      : 'SELECT * FROM wiki ORDER BY id DESC';
+    const results = limit
+      ? runSelect<Wiki>(sql, [Number(limit)])
+      : runSelect<Wiki>(sql);
+    return NextResponse.json(results);
+  } catch (error) {
+    return NextResponse.json({ error: 'DB取得失敗' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { title, content } = body;
+    if (!title || !content) {
+      return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
+    }
+    runExecute('INSERT INTO wiki (title, content) VALUES (?, ?)', [title, content]);
+    return NextResponse.json({ message: '登録成功' });
+  } catch (error) {
+    return NextResponse.json({ error: '登録失敗' }, { status: 500 });
+  }
+}

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -1,0 +1,19 @@
+'use client';
+import type { Wiki } from '@/types/wiki';
+import Link from 'next/link';
+
+type Props = { wikis: Wiki[] };
+
+const WikiCards: React.FC<Props> = ({ wikis }) => (
+  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+    {wikis.map((wiki) => (
+      <div key={wiki.id} className="border rounded p-4 bg-white shadow">
+        <h3 className="font-bold mb-2 truncate">{wiki.title}</h3>
+        <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{wiki.content}</p>
+        <Link href={`/wikis/${wiki.id}`} className="text-blue-600 hover:underline">詳細</Link>
+      </div>
+    ))}
+  </div>
+);
+
+export default WikiCards;

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Wiki } from '@/types/wiki';
+
+const WikiDetailPage = ({ params }: { params: { id: string } }) => {
+  const router = useRouter();
+  const [wiki, setWiki] = useState<Wiki | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/wiki/${params.id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Wiki = await res.json();
+        setWiki(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, [params.id]);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!wiki) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{wiki.title}</h1>
+      <p className="whitespace-pre-wrap border p-4 rounded bg-white">{wiki.content}</p>
+      <button onClick={() => router.push(`/wikis/edit/${wiki.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">編集</button>
+    </div>
+  );
+};
+
+export default WikiDetailPage;

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import type { Wiki } from '@/types/wiki';
+
+const WikiEditPage = ({ params }: { params: { id: string } }) => {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/wiki/${params.id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const wiki: Wiki = await res.json();
+        setTitle(wiki.title);
+        setContent(wiki.content);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [params.id]);
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/wiki/${params.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    if (res.ok) {
+      router.push(`/wikis/${params.id}`);
+    } else {
+      alert('更新失敗');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/wiki/${params.id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/wikis');
+    } else {
+      alert('削除失敗');
+    }
+  };
+
+  if (loading) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Wiki編集</h1>
+      <form onSubmit={handleUpdate} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input value={title} onChange={e => setTitle(e.target.value)} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">内容</label>
+          <textarea value={content} onChange={e => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
+        </div>
+        <div className="space-x-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
+          <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default WikiEditPage;

--- a/src/app/wikis/new/page.tsx
+++ b/src/app/wikis/new/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const NewWikiPage = () => {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/wiki', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    if (res.ok) {
+      router.push('/wikis');
+    } else {
+      alert('登録失敗');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Wiki作成</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input value={title} onChange={e => setTitle(e.target.value)} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">内容</label>
+          <textarea value={content} onChange={e => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
+        </div>
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+      </form>
+    </div>
+  );
+};
+
+export default NewWikiPage;

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Wiki } from '@/types/wiki';
+
+const WikiListPage = () => {
+  const [wikis, setWikis] = useState<Wiki[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/wiki');
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Wiki[] = await res.json();
+        setWikis(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, []);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!wikis) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Wiki一覧</h1>
+      <Link href="/wikis/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
+      <ul className="space-y-2">
+        {wikis.map((wiki) => (
+          <li key={wiki.id} className="border p-4 rounded">
+            <Link href={`/wikis/${wiki.id}`} className="font-semibold hover:underline">
+              {wiki.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default WikiListPage;

--- a/src/types/wiki.d.ts
+++ b/src/types/wiki.d.ts
@@ -1,0 +1,6 @@
+export type Wiki = {
+  id: number;
+  title: string;
+  content: string;
+  created_at: string;
+};


### PR DESCRIPTION
## Summary
- add a `Wiki登録` button in the dashboard header before the password button
- style wiki and password buttons with different colors

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475c28f33083329658c2be98bd91e0