### PR TITLE
Render wiki pages with Markdown

### DIFF
--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
 const WikiDetailPage = ({ params }: { params: { id: string } }) => {
@@ -28,8 +31,19 @@ const WikiDetailPage = ({ params }: { params: { id: string } }) => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{wiki.title}</h1>
-      <p className="whitespace-pre-wrap border p-4 rounded bg-white">{wiki.content}</p>
-      <button onClick={() => router.push(`/wikis/edit/${wiki.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">編集</button>
+      <ReactMarkdown
+        className="prose whitespace-pre-wrap border p-4 rounded bg-white"
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+      >
+        {wiki.content}
+      </ReactMarkdown>
+      <button
+        onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        編集
+      </button>
     </div>
   );
 };

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
 const WikiListPage = () => {
@@ -30,10 +33,20 @@ const WikiListPage = () => {
       <Link href="/wikis/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
       <ul className="space-y-2">
         {wikis.map((wiki) => (
-          <li key={wiki.id} className="border p-4 rounded">
-            <Link href={`/wikis/${wiki.id}`} className="font-semibold hover:underline">
+          <li key={wiki.id} className="border p-4 rounded space-y-2">
+            <Link
+              href={`/wikis/${wiki.id}`}
+              className="font-semibold hover:underline block"
+            >
               {wiki.title}
             </Link>
+            <ReactMarkdown
+              className="prose line-clamp-3 text-sm"
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight]}
+            >
+              {wiki.content}
+            </ReactMarkdown>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- render wiki content using ReactMarkdown in wiki detail page
- show markdown preview for each wiki in the list page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1ef5495083328a9900f4a680f786