### PR TITLE
Fix React imports for client pages

### DIFF
--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { Password } from '@/types/password';

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import React from 'react';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import type { Wiki } from '@/types/wiki';


### PR DESCRIPTION
## Summary
- import React in dynamic pages that use `React.use`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c23436dcc83328faa17a15d7af92c