### PR TITLE
Fix ReactMarkdown className crash

### DIFF
--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -32,13 +32,14 @@ const WikiDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{wiki.title}</h1>
-      <ReactMarkdown
-        className="prose whitespace-pre-wrap border p-4 rounded bg-white"
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeHighlight]}
-      >
-        {wiki.content}
-      </ReactMarkdown>
+      <div className="prose whitespace-pre-wrap border p-4 rounded bg-white">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeHighlight]}
+        >
+          {wiki.content}
+        </ReactMarkdown>
+      </div>
       <button
         onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
         className="bg-blue-500 text-white px-4 py-2 rounded"

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -40,13 +40,14 @@ const WikiListPage = () => {
             >
               {wiki.title}
             </Link>
-            <ReactMarkdown
-              className="prose line-clamp-3 text-sm"
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeHighlight]}
-            >
-              {wiki.content}
-            </ReactMarkdown>
+            <div className="prose line-clamp-3 text-sm">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeHighlight]}
+              >
+                {wiki.content}
+              </ReactMarkdown>
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- fix `react-markdown` usage by removing unsupported `className` prop

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c24c78d6883328d83da73b6141ad2