### PR TITLE
Fix markdown pages and add theme toggle

### DIFF
--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+const ThemeToggle = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const dark = stored === 'dark' || (!stored && prefersDark);
+    document.documentElement.classList.toggle('dark', dark);
+    setIsDark(dark);
+  }, []);
+
+  const toggle = () => {
+    const newDark = !isDark;
+    document.documentElement.classList.toggle('dark', newDark);
+    localStorage.setItem('theme', newDark ? 'dark' : 'light');
+    setIsDark(newDark);
+  };
+
+  return (
+    <button onClick={toggle} className="ml-2 px-2 py-1 border rounded">
+      {isDark ? 'ライト' : 'ダーク'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,11 @@
   }
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import React from 'react';
 import Link from 'next/link';
+import ThemeToggle from './components/ThemeToggle';
 
 const RootLayout = ({
   children,
@@ -9,14 +10,15 @@ const RootLayout = ({
 }) => {
   return (
     <html lang="ja">
-      <body className="font-sans bg-gray-100 text-gray-800 flex flex-col min-h-screen">
-        <header className="bg-blue-500 text-white py-4 px-6 fixed top-0 w-full z-10">
+      <body className="font-sans flex flex-col min-h-screen">
+        <header className="bg-blue-500 text-white py-4 px-6 fixed top-0 w-full z-10 flex justify-between">
           <h1 className="text-lg font-bold">
             <Link href="/" className="block focus:outline-none focus:ring">
               プライベートデスク
               <span className="sr-only"> - このアプリの共通レイアウト</span>
             </Link>
           </h1>
+          <ThemeToggle />
         </header>
 
         <main className="flex-grow p-6 overflow-auto mt-16 mb-16">

--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { Password } from '@/types/password';
 
-const UpdatePasswordPage = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = React.use(params);
+const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
+  const { id } = params;
   const router = useRouter();
   const [idState] = useState<string>(id);
   const [siteName, setSiteName] = useState('');

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -6,8 +6,8 @@ import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
-const WikiDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = React.use(params);
+const WikiDetailPage = ({ params }: { params: { id: string } }) => {
+  const { id } = params;
   const router = useRouter();
   const [wiki, setWiki] = useState<Wiki | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -4,8 +4,8 @@ import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import type { Wiki } from '@/types/wiki';
 
-const WikiEditPage = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = React.use(params);
+const WikiEditPage = ({ params }: { params: { id: string } }) => {
+  const { id } = params;
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');


### PR DESCRIPTION
## Summary
- fix route params usage for edit pages
- add dark mode toggle component
- expose toggle in layout header
- support class-based dark theme in globals.css

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c980d7fac833280cf498d682ed461