### PR TITLE
Improve Markdown styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@tailwindcss/typography": "^0.5.12",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,3 +29,17 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Styling for rendered Markdown */
+.markdown-body {
+  line-height: 1.75;
+  max-width: 100%;
+}
+
+.markdown-body h1 {
+  @apply text-3xl font-bold mb-4 border-b pb-2;
+}
+
+.markdown-body pre {
+  @apply bg-gray-800 text-white p-4 rounded-md overflow-x-auto;
+}

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -32,7 +32,7 @@ const WikiDetailPage = ({ params }: { params: { id: string } }) => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{wiki.title}</h1>
-      <div className="prose whitespace-pre-wrap border p-4 rounded bg-white">
+      <div className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeHighlight]}

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -40,7 +40,7 @@ const WikiListPage = () => {
             >
               {wiki.title}
             </Link>
-            <div className="prose line-clamp-3 text-sm">
+            <div className="markdown-body line-clamp-3 text-sm">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeHighlight]}


### PR DESCRIPTION
## Summary
- style Markdown rendering with custom `.markdown-body` class
- use the new class on Wiki pages
- add `@tailwindcss/typography` to dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9fba7fa0833298cdc67039442dee