### PR TITLE
Add diary feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ npm start
 
 ## DATABASEテーブル構成
 
+```
+CREATE TABLE diary (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -19,5 +19,11 @@ db.exec(`
     content TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
+  CREATE TABLE IF NOT EXISTS diary (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 `);
-console.log('パスワード管理テーブルとwikiテーブルを作成しました');
+console.log('パスワード管理テーブルとwikiテーブル、diaryテーブルを作成しました');

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -4,12 +4,15 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import PasswordList from '../components/PasswordList';
 import WikiCards from '../components/WikiCards';
+import DiaryCards from '../components/DiaryCards';
 import type { Password } from '@/types/password';
 import type { Wiki } from '@/types/wiki';
+import type { Diary } from '@/types/diary';
 
 const MainPage = () => {
   const [passwords, setPasswords] = useState<Password[]>([]);
   const [wikis, setWikis] = useState<Wiki[]>([]);
+  const [diaries, setDiaries] = useState<Diary[]>([]);
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState<{ diaries?: string; wikis?: string; passwords?: string }>({});
 
@@ -34,6 +37,7 @@ const MainPage = () => {
       await Promise.all([
         fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
         fetchData<Wiki[]>('/api/wiki?limit=3', setWikis, 'wikis'),
+        fetchData<Diary[]>('/api/diary?limit=3', setDiaries, 'diaries'),
       ]);
       setLoading(false);
     };
@@ -56,6 +60,12 @@ const MainPage = () => {
             Wiki登録
           </Link>
           <Link
+            href="/diaries/new"
+            className="bg-purple-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-purple-600 active:scale-95 transition-transform"
+          >
+            日報登録
+          </Link>
+          <Link
             href="/passwords/new"
             className="bg-green-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-green-600 active:scale-95 transition-transform"
           >
@@ -74,6 +84,21 @@ const MainPage = () => {
         )}
         <div className="mt-2">
           <Link href="/wikis" className="text-blue-600 hover:underline">
+            一覧を見る
+          </Link>
+        </div>
+      </section>
+      <section className="my-6">
+        <h2 className="text-xl font-semibold">最新日報</h2>
+        {errors.diaries ? (
+          <p className="text-red-500">{errors.diaries}</p>
+        ) : diaries.length > 0 ? (
+          <DiaryCards diaries={diaries} />
+        ) : (
+          <p className="text-gray-500">登録された日報がありません。</p>
+        )}
+        <div className="mt-2">
+          <Link href="/diaries" className="text-blue-600 hover:underline">
             一覧を見る
           </Link>
         </div>

--- a/src/app/api/diary/[id]/route.ts
+++ b/src/app/api/diary/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Diary } from '@/types/diary';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid diary ID.' }, { status: 400 });
+  }
+  try {
+    const result = runGet<Diary>('SELECT * FROM diary WHERE id = ?', [Number(id)]);
+    if (!result) {
+      return NextResponse.json({ error: 'diary entry not found.' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch diary entry.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { title, content } = body;
+    if (!title || !content) {
+      return NextResponse.json({ error: 'title and content are required.' }, { status: 400 });
+    }
+    runExecute('UPDATE diary SET title = ?, content = ? WHERE id = ?', [title, content, Number(id)]);
+    return NextResponse.json({ message: 'diary entry updated successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to update diary entry.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM diary WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'diary entry deleted successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete diary entry.' }, { status: 500 });
+  }
+}

--- a/src/app/api/diary/route.ts
+++ b/src/app/api/diary/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { runSelect, runExecute } from '@/lib/db';
+import type { Diary } from '@/types/diary';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit');
+  try {
+    const sql = limit
+      ? 'SELECT * FROM diary ORDER BY id DESC LIMIT ?'
+      : 'SELECT * FROM diary ORDER BY id DESC';
+    const results = limit
+      ? runSelect<Diary>(sql, [Number(limit)])
+      : runSelect<Diary>(sql);
+    return NextResponse.json(results);
+  } catch (error) {
+    return NextResponse.json({ error: 'DB取得失敗' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { title, content } = body;
+    if (!title || !content) {
+      return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
+    }
+    runExecute('INSERT INTO diary (title, content) VALUES (?, ?)', [title, content]);
+    return NextResponse.json({ message: '登録成功' });
+  } catch (error) {
+    return NextResponse.json({ error: '登録失敗' }, { status: 500 });
+  }
+}

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -1,0 +1,25 @@
+'use client';
+import type { Diary } from '@/types/diary';
+import { useRouter } from 'next/navigation';
+
+type Props = { diaries: Diary[] };
+
+const DiaryCards: React.FC<Props> = ({ diaries }) => {
+  const router = useRouter();
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {diaries.map((diary) => (
+        <div key={diary.id} className="border rounded p-4 bg-white shadow">
+          <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{diary.content}</p>
+          <button onClick={() => router.push(`/diaries/${diary.id}`)} className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">
+            詳細
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DiaryCards;

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import type { Diary } from '@/types/diary';
+
+const DiaryDetailPage = ({ params }: { params: { id: string } }) => {
+  const { id } = React.use(params);
+  const router = useRouter();
+  const [diary, setDiary] = useState<Diary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/diary/${id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Diary = await res.json();
+        setDiary(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!diary) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{diary.title}</h1>
+      <div className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+          {diary.content}
+        </ReactMarkdown>
+      </div>
+      <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">
+        編集
+      </button>
+    </div>
+  );
+};
+
+export default DiaryDetailPage;

--- a/src/app/diaries/edit/[id]/page.tsx
+++ b/src/app/diaries/edit/[id]/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import type { Diary } from '@/types/diary';
+
+const DiaryEditPage = ({ params }: { params: { id: string } }) => {
+  const { id } = React.use(params);
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/diary/${id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const diary: Diary = await res.json();
+        setTitle(diary.title);
+        setContent(diary.content);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/diary/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    if (res.ok) {
+      router.push(`/diaries/${id}`);
+    } else {
+      alert('更新失敗');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/diary/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/diaries');
+    } else {
+      alert('削除失敗');
+    }
+  };
+
+  if (loading) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">日報編集</h1>
+      <form onSubmit={handleUpdate} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">内容</label>
+          <textarea value={content} onChange={(e) => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
+        </div>
+        <div className="space-x-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
+          <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default DiaryEditPage;

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const NewDiaryPage = () => {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/diary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content }),
+    });
+    if (res.ok) {
+      router.push('/diaries');
+    } else {
+      alert('登録失敗');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">日報作成</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input value={title} onChange={(e) => setTitle(e.target.value)} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">内容</label>
+          <textarea value={content} onChange={(e) => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
+        </div>
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+      </form>
+    </div>
+  );
+};
+
+export default NewDiaryPage;

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import type { Diary } from '@/types/diary';
+
+const DiaryListPage = () => {
+  const [diaries, setDiaries] = useState<Diary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/diary');
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Diary[] = await res.json();
+        setDiaries(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, []);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!diaries) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">日報一覧</h1>
+      <Link href="/diaries/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
+      <ul className="space-y-2">
+        {diaries.map((diary) => (
+          <li key={diary.id} className="border p-4 rounded space-y-2">
+            <Link href={`/diaries/${diary.id}`} className="font-semibold hover:underline block">
+              {diary.title}
+            </Link>
+            <div className="markdown-body line-clamp-3 text-sm">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                {diary.content}
+              </ReactMarkdown>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DiaryListPage;

--- a/src/types/diary.d.ts
+++ b/src/types/diary.d.ts
@@ -1,0 +1,6 @@
+export type Diary = {
+  id: number;
+  title: string;
+  content: string;
+  created_at: string;
+};

--- a/tests/api/diary.test.ts
+++ b/tests/api/diary.test.ts
@@ -1,0 +1,48 @@
+import { GET, POST } from '../../src/app/api/diary/route';
+import { runSelect, runExecute } from '../../src/lib/db';
+
+function createPostRequest(body: any) {
+  return new Request('http://localhost/api/diary', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/diary', () => {
+  it('should return list of diaries', async () => {
+    const req = new Request('http://localhost/api/diary');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+describe('POST /api/diary', () => {
+  const entry = {
+    title: 'jest diary',
+    content: 'content',
+  };
+
+  afterAll(() => {
+    runExecute('DELETE FROM diary WHERE title = ?', [entry.title]);
+  });
+
+  it('should create a diary entry', async () => {
+    const req = createPostRequest(entry);
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ message: '登録成功' });
+
+    const rows = runSelect('SELECT * FROM diary WHERE title = ?', [entry.title]);
+    expect(rows.length).toBe(1);
+  });
+
+  it('should return 400 when required fields missing', async () => {
+    const req = createPostRequest({});
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- implement diary CRUD API and pages
- show latest diaries in dashboard
- include diary cards component
- initialize diary table in DB setup
- document diary schema
- add API tests for diary endpoints

## Testing
- `npm test` *(fails: jest not installed)*
- `npm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d6e7741248332a30b11a715893ab3