### PR TITLE
Add blog management features

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -25,5 +25,16 @@ db.exec(`
     content TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
+  CREATE TABLE IF NOT EXISTS blog (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_markdown TEXT NOT NULL,
+    content_html TEXT NOT NULL,
+    site TEXT NOT NULL,
+    author TEXT NOT NULL,
+    persona TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 `);
-console.log('パスワード管理テーブルとwikiテーブル、diaryテーブルを作成しました');
+console.log('パスワード管理テーブルとwikiテーブル、diaryテーブル、blogテーブルを作成しました');

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -5,16 +5,19 @@ import Link from 'next/link';
 import PasswordList from '../components/PasswordList';
 import WikiCards from '../components/WikiCards';
 import DiaryCards from '../components/DiaryCards';
+import BlogCards from '../components/BlogCards';
 import type { Password } from '@/types/password';
 import type { Wiki } from '@/types/wiki';
 import type { Diary } from '@/types/diary';
+import type { Blog } from '@/types/blog';
 
 const MainPage = () => {
   const [passwords, setPasswords] = useState<Password[]>([]);
   const [wikis, setWikis] = useState<Wiki[]>([]);
   const [diaries, setDiaries] = useState<Diary[]>([]);
+  const [blogs, setBlogs] = useState<Blog[]>([]);
   const [loading, setLoading] = useState(true);
-  const [errors, setErrors] = useState<{ diaries?: string; wikis?: string; passwords?: string }>({});
+  const [errors, setErrors] = useState<{ diaries?: string; wikis?: string; passwords?: string; blogs?: string }>({});
 
   const fetchData = useCallback(async <T,>(
     url: string,
@@ -38,6 +41,7 @@ const MainPage = () => {
         fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
         fetchData<Wiki[]>('/api/wiki?limit=3', setWikis, 'wikis'),
         fetchData<Diary[]>('/api/diary?limit=3', setDiaries, 'diaries'),
+        fetchData<Blog[]>('/api/blog?limit=3', setBlogs, 'blogs'),
       ]);
       setLoading(false);
     };
@@ -64,6 +68,12 @@ const MainPage = () => {
             className="bg-purple-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-purple-600 active:scale-95 transition-transform"
           >
             日報登録
+          </Link>
+          <Link
+            href="/blogs/new"
+            className="bg-indigo-500 text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-indigo-600 active:scale-95 transition-transform"
+          >
+            ブログ登録
           </Link>
           <Link
             href="/passwords/new"
@@ -99,6 +109,21 @@ const MainPage = () => {
         )}
         <div className="mt-2">
           <Link href="/diaries" className="text-blue-600 hover:underline">
+            一覧を見る
+          </Link>
+        </div>
+      </section>
+      <section className="my-6">
+        <h2 className="text-xl font-semibold">最新ブログ</h2>
+        {errors.blogs ? (
+          <p className="text-red-500">{errors.blogs}</p>
+        ) : blogs.length > 0 ? (
+          <BlogCards blogs={blogs} />
+        ) : (
+          <p className="text-gray-500">登録されたブログがありません。</p>
+        )}
+        <div className="mt-2">
+          <Link href="/blogs" className="text-blue-600 hover:underline">
             一覧を見る
           </Link>
         </div>

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { runSelect, runExecute } from '@/lib/db';
+import type { Blog } from '@/types/blog';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const limit = searchParams.get('limit');
+  try {
+    const sql = limit
+      ? 'SELECT * FROM blog ORDER BY id DESC LIMIT ?'
+      : 'SELECT * FROM blog ORDER BY id DESC';
+    const results = limit
+      ? runSelect<Blog>(sql, [Number(limit)])
+      : runSelect<Blog>(sql);
+    return NextResponse.json(results);
+  } catch (error) {
+    return NextResponse.json({ error: 'DB取得失敗' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { title, content, content_markdown, content_html, site, author, persona } = body;
+    if (!title || !content || !content_markdown || !content_html || !site || !author || !persona) {
+      return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
+    }
+    runExecute(
+      'INSERT INTO blog (title, content, content_markdown, content_html, site, author, persona) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [title, content, content_markdown, content_html, site, author, persona]
+    );
+    return NextResponse.json({ message: '登録成功' });
+  } catch (error) {
+    return NextResponse.json({ error: '登録失敗' }, { status: 500 });
+  }
+}

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const NewBlogPage = () => {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    title: '',
+    content: '',
+    content_markdown: '',
+    content_html: '',
+    site: '',
+    author: '',
+    persona: '',
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/blog', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      router.push('/blogs');
+    } else {
+      alert('登録失敗');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">ブログ登録</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input
+            name="title"
+            value={form.title}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ</label>
+          <textarea
+            name="content"
+            value={form.content}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ(Markdown)</label>
+          <textarea
+            name="content_markdown"
+            value={form.content_markdown}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ(HTML)</label>
+          <textarea
+            name="content_html"
+            value={form.content_html}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">ブログサイト</label>
+          <input
+            name="site"
+            value={form.site}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">著者情報</label>
+          <input
+            name="author"
+            value={form.author}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">ペルソナ情報</label>
+          <input
+            name="persona"
+            value={form.persona}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+          登録
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default NewBlogPage;

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Blog } from '@/types/blog';
+
+const BlogListPage = () => {
+  const [blogs, setBlogs] = useState<Blog[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/blog');
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Blog[] = await res.json();
+        setBlogs(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, []);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!blogs) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">ブログ一覧</h1>
+      <Link href="/blogs/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
+      <ul className="space-y-2">
+        {blogs.map((blog) => (
+          <li key={blog.id} className="border p-4 rounded space-y-2">
+            <h3 className="font-semibold">{blog.title}</h3>
+            <p className="text-sm line-clamp-3 whitespace-pre-wrap">{blog.content}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default BlogListPage;

--- a/src/app/components/BlogCards.tsx
+++ b/src/app/components/BlogCards.tsx
@@ -1,0 +1,21 @@
+'use client';
+import type { Blog } from '@/types/blog';
+import { useRouter } from 'next/navigation';
+
+type Props = { blogs: Blog[] };
+
+const BlogCards: React.FC<Props> = ({ blogs }) => {
+  const router = useRouter();
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {blogs.map((blog) => (
+        <div key={blog.id} className="border rounded p-4 bg-white shadow">
+          <h3 className="font-bold mb-2 truncate">{blog.title}</h3>
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{blog.content}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BlogCards;

--- a/src/types/blog.d.ts
+++ b/src/types/blog.d.ts
@@ -1,0 +1,11 @@
+export type Blog = {
+  id: number;
+  title: string;
+  content: string;
+  content_markdown: string;
+  content_html: string;
+  site: string;
+  author: string;
+  persona: string;
+  created_at: string;
+};

--- a/tests/api/blog.test.ts
+++ b/tests/api/blog.test.ts
@@ -1,0 +1,53 @@
+import { GET, POST } from '../../src/app/api/blog/route';
+import { runSelect, runExecute } from '../../src/lib/db';
+
+function createPostRequest(body: any) {
+  return new Request('http://localhost/api/blog', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('GET /api/blog', () => {
+  it('should return list of blogs', async () => {
+    const req = new Request('http://localhost/api/blog');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+});
+
+describe('POST /api/blog', () => {
+  const entry = {
+    title: 'jest blog',
+    content: 'c',
+    content_markdown: 'md',
+    content_html: '<p>c</p>',
+    site: 'example.com',
+    author: 'jest',
+    persona: 'tester',
+  };
+
+  afterAll(() => {
+    runExecute('DELETE FROM blog WHERE title = ?', [entry.title]);
+  });
+
+  it('should create a blog entry', async () => {
+    const req = createPostRequest(entry);
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ message: '登録成功' });
+
+    const rows = runSelect('SELECT * FROM blog WHERE title = ?', [entry.title]);
+    expect(rows.length).toBe(1);
+  });
+
+  it('should return 400 when required fields missing', async () => {
+    const req = createPostRequest({});
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- create database table and type for blogs
- implement `/api/blog` for retrieval and creation
- add blog registration page and listing page
- show recent blogs on dashboard via new `BlogCards` component
- include jest test for blog API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690671552c83329277078214ceca7b