### PR TITLE
Add blog detail and edit features

### DIFF
--- a/src/app/api/blog/[id]/route.ts
+++ b/src/app/api/blog/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Blog } from '@/types/blog';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid blog ID.' }, { status: 400 });
+  }
+  try {
+    const result = runGet<Blog>('SELECT * FROM blog WHERE id = ?', [Number(id)]);
+    if (!result) {
+      return NextResponse.json({ error: 'blog entry not found.' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch blog entry.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { title, content, content_markdown, content_html, site, author, persona } = body;
+    if (!title || !content || !content_markdown || !content_html || !site || !author || !persona) {
+      return NextResponse.json({ error: 'required fields missing.' }, { status: 400 });
+    }
+    runExecute(
+      'UPDATE blog SET title = ?, content = ?, content_markdown = ?, content_html = ?, site = ?, author = ?, persona = ? WHERE id = ?',
+      [title, content, content_markdown, content_html, site, author, persona, Number(id)]
+    );
+    return NextResponse.json({ message: 'blog entry updated successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to update blog entry.' }, { status: 500 });
+  }
+}

--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Blog } from '@/types/blog';
+
+const BlogDetailPage = ({ params }: { params: { id: string } }) => {
+  const { id } = React.use(params);
+  const router = useRouter();
+  const [blog, setBlog] = useState<Blog | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/blog/${id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const data: Blog = await res.json();
+        setBlog(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (error) return <div>読み込みエラー</div>;
+  if (!blog) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{blog.title}</h1>
+      <div className="whitespace-pre-wrap border p-4 rounded bg-white">
+        {blog.content}
+      </div>
+      <button
+        onClick={() => router.push(`/blogs/edit/${blog.id}`)}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        編集
+      </button>
+    </div>
+  );
+};
+
+export default BlogDetailPage;

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -1,0 +1,151 @@
+'use client';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import type { Blog } from '@/types/blog';
+
+const BlogEditPage = ({ params }: { params: { id: string } }) => {
+  const { id } = React.use(params);
+  const router = useRouter();
+  const [form, setForm] = useState({
+    title: '',
+    content: '',
+    content_markdown: '',
+    content_html: '',
+    site: '',
+    author: '',
+    persona: '',
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/blog/${id}`);
+        if (!res.ok) throw new Error('読み込み失敗');
+        const blog: Blog = await res.json();
+        setForm({
+          title: blog.title,
+          content: blog.content,
+          content_markdown: blog.content_markdown,
+          content_html: blog.content_html,
+          site: blog.site,
+          author: blog.author,
+          persona: blog.persona,
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/blog/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      router.push(`/blogs/${id}`);
+    } else {
+      alert('更新失敗');
+    }
+  };
+
+  if (loading) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">ブログ編集</h1>
+      <form onSubmit={handleUpdate} className="space-y-2">
+        <div>
+          <label className="block">タイトル</label>
+          <input
+            name="title"
+            value={form.title}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ</label>
+          <textarea
+            name="content"
+            value={form.content}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ(Markdown)</label>
+          <textarea
+            name="content_markdown"
+            value={form.content_markdown}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">コンテンツ(HTML)</label>
+          <textarea
+            name="content_html"
+            value={form.content_html}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            rows={4}
+            required
+          />
+        </div>
+        <div>
+          <label className="block">ブログサイト</label>
+          <input
+            name="site"
+            value={form.site}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">著者情報</label>
+          <input
+            name="author"
+            value={form.author}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">ペルソナ情報</label>
+          <input
+            name="persona"
+            value={form.persona}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+          更新
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default BlogEditPage;

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -31,7 +31,12 @@ const BlogListPage = () => {
       <ul className="space-y-2">
         {blogs.map((blog) => (
           <li key={blog.id} className="border p-4 rounded space-y-2">
-            <h3 className="font-semibold">{blog.title}</h3>
+            <Link
+              href={`/blogs/${blog.id}`}
+              className="font-semibold hover:underline block"
+            >
+              {blog.title}
+            </Link>
             <p className="text-sm line-clamp-3 whitespace-pre-wrap">{blog.content}</p>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- implement API for fetching/updating individual blogs
- add blog detail page
- add blog edit page
- link blog list to detail page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690b3f171483329efd911bd414746d