### PR TITLE
Add Ollama blog generation feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OLLAMA_HOST=localhost
+OLLAMA_PORT=11434

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Private Desk は Next.js と SQLite を用いたシンプルなパスワード�
    npx ts-node scripts/init-db.ts
    ```
    上記コマンドにより `data/database.sqlite` が作成されます。
+3. .env ファイルの作成
+   `.env.example` をコピーして `.env` を作成し、必要に応じて Ollama のホストとポートを設定します。
 
 ## 開発サーバの起動
 
@@ -70,5 +72,15 @@ CREATE TABLE diary (
     content TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+```
+
+## Ollama 連携
+
+ブログ生成機能ではローカルLLMである [Ollama](https://ollama.ai/) を利用します。
+`.env` に以下の環境変数を設定してホストとポートを指定してください。
+
+```bash
+OLLAMA_HOST=localhost
+OLLAMA_PORT=11434
 ```
 

--- a/src/app/api/blog/generate/route.ts
+++ b/src/app/api/blog/generate/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { prompt } = await req.json();
+    if (!prompt) {
+      return NextResponse.json({ error: 'prompt required' }, { status: 400 });
+    }
+    const host = process.env.OLLAMA_HOST || 'localhost';
+    const port = process.env.OLLAMA_PORT || '11434';
+    const res = await fetch(`http://${host}:${port}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: 'LLM request failed' }, { status: 500 });
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json({ error: 'LLM fetch error' }, { status: 500 });
+  }
+}

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -13,6 +13,7 @@ const NewBlogPage = () => {
     author: '',
     persona: '',
   });
+  const [prompt, setPrompt] = useState('');
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -35,10 +36,41 @@ const NewBlogPage = () => {
     }
   };
 
+  const handleGenerate = async () => {
+    const res = await fetch('/api/blog/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const generated = data.response ?? data.content ?? '';
+      setForm({ ...form, content: generated });
+    } else {
+      alert('生成失敗');
+    }
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">ブログ登録</h1>
       <form onSubmit={handleSubmit} className="space-y-2">
+        <div>
+          <label className="block">生成プロンプト</label>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            className="w-full border p-2 rounded"
+            rows={4}
+          />
+          <button
+            type="button"
+            onClick={handleGenerate}
+            className="bg-green-500 text-white px-4 py-2 rounded mt-2"
+          >
+            ブログ生成
+          </button>
+        </div>
         <div>
           <label className="block">タイトル</label>
           <input

--- a/tests/api/blogGenerate.test.ts
+++ b/tests/api/blogGenerate.test.ts
@@ -1,0 +1,38 @@
+import { POST } from '../../src/app/api/blog/generate/route';
+
+
+describe('POST /api/blog/generate', () => {
+  const origFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('should call ollama and return response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: 'ok' }),
+    }) as any;
+
+    const req = new Request('http://localhost/api/blog/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'hi' }),
+    });
+
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ response: 'ok' });
+  });
+
+  it('should return 400 when prompt missing', async () => {
+    const req = new Request('http://localhost/api/blog/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- create `.env.example` with OLLAMA variables
- document Ollama setup in `README.md`
- add API route `api/blog/generate` to call Ollama using env vars
- extend blog creation page with prompt field and generation button
- test the new API route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686910190e2483328f8b852159cc7924