### PR TITLE
Add unified search page

### DIFF
--- a/public/search.svg
+++ b/public/search.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m2.1-5.4a7.5 7.5 0 11-15 0 7.5 7.5 0 0115 0z" />
+</svg>

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { runSelect } from '@/lib/db';
+import type { Password } from '@/types/password';
+import type { Diary } from '@/types/diary';
+import type { Wiki } from '@/types/wiki';
+import type { Blog } from '@/types/blog';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q');
+  if (!q) {
+    return NextResponse.json({ error: 'query required' }, { status: 400 });
+  }
+  const like = `%${q}%`;
+  try {
+    const passwords = runSelect<Password>(
+      'SELECT * FROM password_manager WHERE site_name LIKE ? OR site_url LIKE ? OR login_id LIKE ? OR email LIKE ? OR memo LIKE ?',
+      [like, like, like, like, like]
+    );
+    const diaries = runSelect<Diary>(
+      'SELECT * FROM diary WHERE title LIKE ? OR content LIKE ?',
+      [like, like]
+    );
+    const wikis = runSelect<Wiki>(
+      'SELECT * FROM wiki WHERE title LIKE ? OR content LIKE ?',
+      [like, like]
+    );
+    const blogs = runSelect<Blog>(
+      'SELECT * FROM blog WHERE title LIKE ? OR content LIKE ?',
+      [like, like]
+    );
+    return NextResponse.json({ passwords, diaries, wikis, blogs });
+  } catch (error) {
+    return NextResponse.json({ error: '検索失敗' }, { status: 500 });
+  }
+}

--- a/src/app/components/PasswordCards.tsx
+++ b/src/app/components/PasswordCards.tsx
@@ -1,0 +1,28 @@
+'use client';
+import type { Password } from '@/types/password';
+import { useRouter } from 'next/navigation';
+
+type Props = { passwords: Password[] };
+
+const PasswordCards: React.FC<Props> = ({ passwords }) => {
+  const router = useRouter();
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {passwords.map((p) => (
+        <div key={p.id} className="border rounded p-4 bg-white shadow">
+          <h3 className="font-bold mb-2 truncate">{p.site_name}</h3>
+          <p className="text-sm break-all mb-1">{p.site_url}</p>
+          {p.login_id && <p className="text-sm break-all mb-1">{p.login_id}</p>}
+          <button
+            onClick={() => router.push(`/passwords/edit/${p.id}`)}
+            className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+          >
+            詳細
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PasswordCards;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,14 +11,27 @@ const RootLayout = ({
   return (
     <html lang="ja">
       <body className="font-sans flex flex-col min-h-screen">
-        <header className="bg-blue-500 text-white py-4 px-6 fixed top-0 w-full z-10 flex justify-between">
+        <header className="bg-blue-500 text-white py-4 px-6 fixed top-0 w-full z-10 flex justify-between items-center">
           <h1 className="text-lg font-bold">
             <Link href="/" className="block focus:outline-none focus:ring">
               プライベートデスク
               <span className="sr-only"> - このアプリの共通レイアウト</span>
             </Link>
           </h1>
-          <ThemeToggle />
+          <div className="flex items-center space-x-2">
+            <form action="/search" className="flex bg-white rounded overflow-hidden">
+              <input
+                type="text"
+                name="q"
+                placeholder="検索"
+                className="px-2 py-1 text-black outline-none"
+              />
+              <button type="submit" className="px-2">
+                <img src="/search.svg" alt="検索" className="w-5 h-5" />
+              </button>
+            </form>
+            <ThemeToggle />
+          </div>
         </header>
 
         <main className="flex-grow p-6 overflow-auto mt-16 mb-16">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import PasswordCards from '../components/PasswordCards';
+import DiaryCards from '../components/DiaryCards';
+import WikiCards from '../components/WikiCards';
+import BlogCards from '../components/BlogCards';
+import type { Password } from '@/types/password';
+import type { Diary } from '@/types/diary';
+import type { Wiki } from '@/types/wiki';
+import type { Blog } from '@/types/blog';
+
+interface Results {
+  passwords: Password[];
+  diaries: Diary[];
+  wikis: Wiki[];
+  blogs: Blog[];
+}
+
+const SearchPage = () => {
+  const params = useSearchParams();
+  const q = params.get('q') || '';
+  const [results, setResults] = useState<Results | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!q) return;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+        if (!res.ok) throw new Error('検索に失敗しました');
+        const data: Results = await res.json();
+        setResults(data);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, [q]);
+
+  if (!q) return <div className="p-4">検索ワードを入力してください。</div>;
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+  if (!results) return <div className="p-4">検索中...</div>;
+
+  return (
+    <div className="space-y-6 p-4">
+      <h1 className="text-2xl font-bold">検索結果: {q}</h1>
+      <section>
+        <h2 className="font-semibold mb-2">パスワード</h2>
+        {results.passwords.length > 0 ? (
+          <PasswordCards passwords={results.passwords} />
+        ) : (
+          <p>該当なし</p>
+        )}
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">Wiki</h2>
+        {results.wikis.length > 0 ? (
+          <WikiCards wikis={results.wikis} />
+        ) : (
+          <p>該当なし</p>
+        )}
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">日報</h2>
+        {results.diaries.length > 0 ? (
+          <DiaryCards diaries={results.diaries} />
+        ) : (
+          <p>該当なし</p>
+        )}
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">ブログ</h2>
+        {results.blogs.length > 0 ? (
+          <BlogCards blogs={results.blogs} />
+        ) : (
+          <p>該当なし</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/tests/api/search.test.ts
+++ b/tests/api/search.test.ts
@@ -1,0 +1,29 @@
+import { GET } from '../../src/app/api/search/route';
+import { runExecute } from '../../src/lib/db';
+
+describe('GET /api/search', () => {
+  const title = 'jest-search-diary';
+
+  beforeAll(() => {
+    runExecute('INSERT INTO diary (title, content) VALUES (?, ?)', [title, 'c']);
+  });
+
+  afterAll(() => {
+    runExecute('DELETE FROM diary WHERE title = ?', [title]);
+  });
+
+  it('should return matching diary', async () => {
+    const req = new Request(`http://localhost/api/search?q=${encodeURIComponent(title)}`);
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    const found = data.diaries.some((d: any) => d.title === title);
+    expect(found).toBe(true);
+  });
+
+  it('should return 400 when query missing', async () => {
+    const req = new Request('http://localhost/api/search');
+    const res = await GET(req as any);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add search input to the header bar
- implement `/api/search` to look up data across all tables
- add new `PasswordCards` component
- display search results in `search/page.tsx`
- include Jest tests for the search API
- add magnifying glass icon

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869cda895e88332b58e28dbd689b201