### PR TITLE
Add schedule calendar feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "@fullcalendar/react": "^6.1.11",
+    "@fullcalendar/daygrid": "^6.1.11",
+    "@fullcalendar/interaction": "^6.1.11",
+    "@headlessui/react": "^1.7.17",
+    "date-fns": "^3.6.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -36,5 +36,14 @@ db.exec(`
     persona TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
+  CREATE TABLE IF NOT EXISTS schedules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    start TEXT NOT NULL,
+    end TEXT NOT NULL,
+    memo TEXT,
+    google_event_id TEXT,
+    createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 `);
-console.log('パスワード管理テーブルとwikiテーブル、diaryテーブル、blogテーブルを作成しました');
+console.log('パスワード管理テーブルとwikiテーブル、diaryテーブル、blogテーブル、schedulesテーブルを作成しました');

--- a/src/app/api/schedule/route.ts
+++ b/src/app/api/schedule/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { runSelect, runExecute } from '@/lib/db';
+import type { Schedule } from '@/types/schedule';
+
+export async function GET() {
+  try {
+    const results = runSelect<Schedule>('SELECT * FROM schedules ORDER BY start');
+    return NextResponse.json(results);
+  } catch (error) {
+    return NextResponse.json({ error: 'DB取得失敗' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { title, start, end, memo } = body;
+    if (!title || !start || !end) {
+      return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
+    }
+    runExecute(
+      'INSERT INTO schedules (title, start, end, memo) VALUES (?, ?, ?, ?)',
+      [title, start, end, memo]
+    );
+    return NextResponse.json({ message: '登録成功' });
+  } catch (error) {
+    return NextResponse.json({ error: '登録失敗' }, { status: 500 });
+  }
+}

--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import FullCalendar, { EventInput } from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin, { DateClickArg } from '@fullcalendar/interaction';
+import { Dialog } from '@headlessui/react';
+import { format } from 'date-fns';
+
+interface FormState {
+  title: string;
+  start: string;
+  end: string;
+  memo: string;
+}
+
+const ScheduleCalendar = () => {
+  const [events, setEvents] = useState<EventInput[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [form, setForm] = useState<FormState>({
+    title: '',
+    start: '',
+    end: '',
+    memo: '',
+  });
+
+  const fetchEvents = async () => {
+    const res = await fetch('/api/schedule');
+    if (res.ok) {
+      const data = await res.json();
+      setEvents(data);
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents();
+  }, []);
+
+  const handleDateClick = (arg: DateClickArg) => {
+    const dateStr = format(arg.date, "yyyy-MM-dd'T'HH:mm");
+    setForm({ title: '', start: dateStr, end: dateStr, memo: '' });
+    setIsOpen(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setIsOpen(false);
+    fetchEvents();
+  };
+
+  return (
+    <div>
+      <FullCalendar
+        plugins={[dayGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        events={events}
+        dateClick={handleDateClick}
+        height="auto"
+      />
+      <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+        <Dialog.Panel className="bg-white rounded p-4 w-full max-w-md">
+          <Dialog.Title className="text-lg font-bold mb-4">予定登録</Dialog.Title>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <label className="block text-sm mb-1">タイトル</label>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                required
+                className="w-full border px-2 py-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">開始</label>
+              <input
+                type="datetime-local"
+                value={form.start}
+                onChange={(e) => setForm({ ...form, start: e.target.value })}
+                required
+                className="w-full border px-2 py-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">終了</label>
+              <input
+                type="datetime-local"
+                value={form.end}
+                onChange={(e) => setForm({ ...form, end: e.target.value })}
+                required
+                className="w-full border px-2 py-1"
+              />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">メモ</label>
+              <textarea
+                value={form.memo}
+                onChange={(e) => setForm({ ...form, memo: e.target.value })}
+                className="w-full border px-2 py-1"
+              />
+            </div>
+            <div className="flex justify-end space-x-2 pt-2">
+              <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-1">キャンセル</button>
+              <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">登録</button>
+            </div>
+          </form>
+        </Dialog.Panel>
+      </Dialog>
+    </div>
+  );
+};
+
+export default ScheduleCalendar;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import PasswordList from '../components/PasswordList';
+import WikiCards from '../components/WikiCards';
+import DiaryCards from '../components/DiaryCards';
+import BlogCards from '../components/BlogCards';
+import ScheduleCalendar from '../components/ScheduleCalendar';
+import type { Password } from '@/types/password';
+import type { Wiki } from '@/types/wiki';
+import type { Diary } from '@/types/diary';
+import type { Blog } from '@/types/blog';
+
+const DashboardPage = () => {
+  const [passwords, setPasswords] = useState<Password[]>([]);
+  const [wikis, setWikis] = useState<Wiki[]>([]);
+  const [diaries, setDiaries] = useState<Diary[]>([]);
+  const [blogs, setBlogs] = useState<Blog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errors, setErrors] = useState<{ diaries?: string; wikis?: string; passwords?: string; blogs?: string }>({});
+
+  const fetchData = useCallback(async <T,>(url: string, setter: (data: T) => void, key: keyof typeof errors) => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`${key}の取得に失敗しました。`);
+      const data: T = await response.json();
+      setter(data);
+    } catch (err) {
+      console.error(`Error fetching ${key}:`, err);
+      setErrors((prev) => ({ ...prev, [key]: (err as Error).message }));
+    }
+  }, []);
+
+  useEffect(() => {
+    const loadData = async () => {
+      await Promise.all([
+        fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
+        fetchData<Wiki[]>('/api/wiki?limit=2', setWikis, 'wikis'),
+        fetchData<Diary[]>('/api/diary?limit=2', setDiaries, 'diaries'),
+        fetchData<Blog[]>('/api/blog?limit=2', setBlogs, 'blogs'),
+      ]);
+      setLoading(false);
+    };
+    loadData();
+  }, [fetchData]);
+
+  if (loading) {
+    return <div>読み込み中...</div>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="space-y-6">
+        <section>
+          <h2 className="text-xl font-semibold">最新Wiki</h2>
+          {errors.wikis ? (
+            <p className="text-red-500">{errors.wikis}</p>
+          ) : wikis.length > 0 ? (
+            <WikiCards wikis={wikis} />
+          ) : (
+            <p className="text-gray-500">登録されたWikiがありません。</p>
+          )}
+          <div className="mt-2">
+            <Link href="/wikis" className="text-blue-600 hover:underline">
+              一覧を見る
+            </Link>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold">最新日報</h2>
+          {errors.diaries ? (
+            <p className="text-red-500">{errors.diaries}</p>
+          ) : diaries.length > 0 ? (
+            <DiaryCards diaries={diaries} />
+          ) : (
+            <p className="text-gray-500">登録された日報がありません。</p>
+          )}
+          <div className="mt-2">
+            <Link href="/diaries" className="text-blue-600 hover:underline">
+              一覧を見る
+            </Link>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold">最新ブログ</h2>
+          {errors.blogs ? (
+            <p className="text-red-500">{errors.blogs}</p>
+          ) : blogs.length > 0 ? (
+            <BlogCards blogs={blogs} />
+          ) : (
+            <p className="text-gray-500">登録されたブログがありません。</p>
+          )}
+          <div className="mt-2">
+            <Link href="/blogs" className="text-blue-600 hover:underline">
+              一覧を見る
+            </Link>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold">パスワード一覧</h2>
+          {errors.passwords ? (
+            <p className="text-red-500">{errors.passwords}</p>
+          ) : passwords.length > 0 ? (
+            <PasswordList passwords={passwords.slice(0,2)} />
+          ) : (
+            <p className="text-gray-500">登録されたパスワードがありません。</p>
+          )}
+        </section>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">予定カレンダー</h2>
+        <ScheduleCalendar />
+      </div>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/src/types/schedule.d.ts
+++ b/src/types/schedule.d.ts
@@ -1,0 +1,9 @@
+export type Schedule = {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+  memo: string | null;
+  google_event_id: string | null;
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
- add new `Schedule` type and API endpoint
- extend database init script for `schedules` table
- add calendar component using FullCalendar and modal form
- update dashboard layout to show latest content and calendar side-by-side
- declare calendar-related dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6bfedb88332a6cc954adb72cf24