### PR TITLE
Shrink schedule calendar

### DIFF
--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -53,7 +53,7 @@ const ScheduleCalendar = () => {
   };
 
   return (
-    <div>
+    <div style={{ transform: 'scale(0.33)', transformOrigin: 'top left' }}>
       <FullCalendar
         plugins={[dayGridPlugin, interactionPlugin]}
         initialView="dayGridMonth"


### PR DESCRIPTION
## Summary
- reduce the displayed size of the schedule calendar to one-third

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e29725c883328ef20b40105d3d8f