### PR TITLE
Add edit and delete features on main cards

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -65,7 +65,10 @@ const MainPage = () => {
           {errors.wikis ? (
             <p className="text-red-500">{errors.wikis}</p>
           ) : wikis.length > 0 ? (
-            <WikiCards wikis={wikis} />
+            <WikiCards
+              wikis={wikis}
+              onDelete={(id) => setWikis(wikis.filter((w) => w.id !== id))}
+            />
           ) : (
             <p className="text-gray-500">登録されたWikiがありません。</p>
           )}
@@ -80,7 +83,10 @@ const MainPage = () => {
           {errors.diaries ? (
             <p className="text-red-500">{errors.diaries}</p>
           ) : diaries.length > 0 ? (
-            <DiaryCards diaries={diaries} />
+            <DiaryCards
+              diaries={diaries}
+              onDelete={(id) => setDiaries(diaries.filter((d) => d.id !== id))}
+            />
           ) : (
             <p className="text-gray-500">登録された日報がありません。</p>
           )}
@@ -95,7 +101,10 @@ const MainPage = () => {
           {errors.blogs ? (
             <p className="text-red-500">{errors.blogs}</p>
           ) : blogs.length > 0 ? (
-            <BlogCards blogs={blogs} />
+            <BlogCards
+              blogs={blogs}
+              onDelete={(id) => setBlogs(blogs.filter((b) => b.id !== id))}
+            />
           ) : (
             <p className="text-gray-500">登録されたブログがありません。</p>
           )}

--- a/src/app/api/blog/[id]/route.ts
+++ b/src/app/api/blog/[id]/route.ts
@@ -35,3 +35,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json({ error: 'Failed to update blog entry.' }, { status: 500 });
   }
 }
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM blog WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'blog entry deleted successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete blog entry.' }, { status: 500 });
+  }
+}

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -61,6 +61,16 @@ const BlogEditPage = ({ params }: { params: { id: string } }) => {
     }
   };
 
+  const handleDelete = async () => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/blog/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/blogs');
+    } else {
+      alert('削除失敗');
+    }
+  };
+
   if (loading) return <div>読み込み中...</div>;
 
   return (
@@ -140,9 +150,10 @@ const BlogEditPage = ({ params }: { params: { id: string } }) => {
             required
           />
         </div>
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-          更新
-        </button>
+        <div className="space-x-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
+          <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/components/BlogCards.tsx
+++ b/src/app/components/BlogCards.tsx
@@ -2,22 +2,46 @@
 import type { Blog } from '@/types/blog';
 import { useRouter } from 'next/navigation';
 
-type Props = { blogs: Blog[] };
+type Props = { blogs: Blog[]; onDelete?: (id: number) => void };
 
-const BlogCards: React.FC<Props> = ({ blogs }) => {
+const BlogCards: React.FC<Props> = ({ blogs, onDelete }) => {
   const router = useRouter();
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/blog/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      onDelete?.(id);
+    } else {
+      alert('削除失敗');
+    }
+  };
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {blogs.map((blog) => (
-        <div key={blog.id} className="border rounded p-4 bg-white shadow">
+        <div key={blog.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{blog.title}</h3>
-          <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{blog.content}</p>
-          <button
-            onClick={() => router.push(`/blogs/${blog.id}`)}
-            className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-          >
-            詳細
-          </button>
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap">{blog.content}</p>
+          <div className="space-x-2">
+            <button
+              onClick={() => router.push(`/blogs/${blog.id}`)}
+              className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+            >
+              詳細
+            </button>
+            <button
+              onClick={() => router.push(`/blogs/edit/${blog.id}`)}
+              className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
+            >
+              編集
+            </button>
+            <button
+              onClick={() => handleDelete(blog.id)}
+              className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+            >
+              削除
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -2,20 +2,38 @@
 import type { Diary } from '@/types/diary';
 import { useRouter } from 'next/navigation';
 
-type Props = { diaries: Diary[] };
+type Props = { diaries: Diary[]; onDelete?: (id: number) => void };
 
-const DiaryCards: React.FC<Props> = ({ diaries }) => {
+const DiaryCards: React.FC<Props> = ({ diaries, onDelete }) => {
   const router = useRouter();
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/diary/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      onDelete?.(id);
+    } else {
+      alert('削除失敗');
+    }
+  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {diaries.map((diary) => (
-        <div key={diary.id} className="border rounded p-4 bg-white shadow">
+        <div key={diary.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
-          <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{diary.content}</p>
-          <button onClick={() => router.push(`/diaries/${diary.id}`)} className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">
-            詳細
-          </button>
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap">{diary.content}</p>
+          <div className="space-x-2">
+            <button onClick={() => router.push(`/diaries/${diary.id}`)} className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">
+              詳細
+            </button>
+            <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">
+              編集
+            </button>
+            <button onClick={() => handleDelete(diary.id)} className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">
+              削除
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -2,23 +2,47 @@
 import type { Wiki } from '@/types/wiki';
 import { useRouter } from 'next/navigation';
 
-type Props = { wikis: Wiki[] };
+type Props = { wikis: Wiki[]; onDelete?: (id: number) => void };
 
-const WikiCards: React.FC<Props> = ({ wikis }) => {
+const WikiCards: React.FC<Props> = ({ wikis, onDelete }) => {
   const router = useRouter();
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/wiki/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      onDelete?.(id);
+    } else {
+      alert('削除失敗');
+    }
+  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {wikis.map((wiki) => (
-        <div key={wiki.id} className="border rounded p-4 bg-white shadow">
+        <div key={wiki.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{wiki.title}</h3>
-          <p className="line-clamp-3 text-sm whitespace-pre-wrap mb-2">{wiki.content}</p>
-          <button
-            onClick={() => router.push(`/wikis/${wiki.id}`)}
-            className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-          >
-            詳細
-          </button>
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap">{wiki.content}</p>
+          <div className="space-x-2">
+            <button
+              onClick={() => router.push(`/wikis/${wiki.id}`)}
+              className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+            >
+              詳細
+            </button>
+            <button
+              onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
+              className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
+            >
+              編集
+            </button>
+            <button
+              onClick={() => handleDelete(wiki.id)}
+              className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+            >
+              削除
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/tests/api/blog.test.ts
+++ b/tests/api/blog.test.ts
@@ -1,9 +1,18 @@
 import { GET, POST } from '../../src/app/api/blog/route';
+import { GET as GET_ID, PUT, DELETE } from '../../src/app/api/blog/[id]/route';
 import { runSelect, runExecute } from '../../src/lib/db';
 
 function createPostRequest(body: any) {
   return new Request('http://localhost/api/blog', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function createPutRequest(id: number, body: any) {
+  return new Request(`http://localhost/api/blog/${id}`, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -49,5 +58,41 @@ describe('POST /api/blog', () => {
     const req = createPostRequest({});
     const res = await POST(req as any);
     expect(res.status).toBe(400);
+  });
+});
+
+describe('Blog update and delete', () => {
+  const entry = {
+    title: 'jest blog2',
+    content: 'c',
+    content_markdown: 'md',
+    content_html: '<p>c</p>',
+    site: 'example.com',
+    author: 'jest',
+    persona: 'tester',
+  };
+  let id: number;
+
+  afterAll(() => {
+    runExecute('DELETE FROM blog WHERE id = ?', [id]);
+  });
+
+  it('should create entry then update and delete', async () => {
+    const createReq = createPostRequest(entry);
+    const createRes = await POST(createReq as any);
+    expect(createRes.status).toBe(200);
+    const row = runSelect('SELECT * FROM blog WHERE title = ?', [entry.title])[0];
+    id = row.id;
+
+    const updateReq = createPutRequest(id, { ...entry, title: 'updated' });
+    const updateRes = await PUT(updateReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(updateRes.status).toBe(200);
+
+    const deleteReq = new Request(`http://localhost/api/blog/${id}`, { method: 'DELETE' });
+    const deleteRes = await DELETE(deleteReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(deleteRes.status).toBe(200);
+
+    const rows = runSelect('SELECT * FROM blog WHERE id = ?', [id]);
+    expect(rows.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- enable deletion for blog API
- add delete support to blog edit screen
- show edit/delete buttons in Wiki, Diary, and Blog card components
- reflect deletions on main page
- extend blog tests for update and delete

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e56d00dc83329341c7cd141cf085