### PR TITLE
Align buttons to right

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -59,17 +59,17 @@ const MainPage = () => {
 
   return (
     <div className="space-y-4">
-      <div className="space-x-2">
-        <Link href="/wikis/new" className="bg-blue-500 text-white px-3 py-1 rounded">
+      <div className="flex justify-end space-x-2">
+        <Link href="/wikis/new" className="bg-blue-500 text-white px-3 py-2 rounded">
           Wiki登録
         </Link>
-        <Link href="/diaries/new" className="bg-purple-500 text-white px-3 py-1 rounded">
+        <Link href="/diaries/new" className="bg-purple-500 text-white px-3 py-2 rounded">
           日報登録
         </Link>
-        <Link href="/blogs/new" className="bg-indigo-500 text-white px-3 py-1 rounded">
+        <Link href="/blogs/new" className="bg-indigo-500 text-white px-3 py-2 rounded">
           ブログ登録
         </Link>
-        <Link href="/passwords/new" className="bg-green-500 text-white px-3 py-1 rounded">
+        <Link href="/passwords/new" className="bg-green-500 text-white px-3 py-2 rounded">
           パスワード登録
         </Link>
       </div>

--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -32,12 +32,14 @@ const BlogDetailPage = ({ params }: { params: { id: string } }) => {
       <div className="whitespace-pre-wrap border p-4 rounded bg-white">
         {blog.content}
       </div>
-      <button
-        onClick={() => router.push(`/blogs/edit/${blog.id}`)}
-        className="bg-blue-500 text-white px-4 py-2 rounded"
-      >
-        編集
-      </button>
+      <div className="flex justify-end">
+        <button
+          onClick={() => router.push(`/blogs/edit/${blog.id}`)}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          編集
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -150,7 +150,7 @@ const BlogEditPage = ({ params }: { params: { id: string } }) => {
             required
           />
         </div>
-        <div className="space-x-2">
+        <div className="flex justify-end space-x-2">
           <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
           <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
         </div>

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -63,13 +63,15 @@ const NewBlogPage = () => {
             className="w-full border p-2 rounded"
             rows={4}
           />
-          <button
-            type="button"
-            onClick={handleGenerate}
-            className="bg-green-500 text-white px-4 py-2 rounded mt-2"
-          >
-            ブログ生成
-          </button>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleGenerate}
+              className="bg-green-500 text-white px-4 py-2 rounded mt-2"
+            >
+              ブログ生成
+            </button>
+          </div>
         </div>
         <div>
           <label className="block">タイトル</label>
@@ -144,9 +146,11 @@ const NewBlogPage = () => {
             required
           />
         </div>
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-          登録
-        </button>
+        <div className="flex justify-end">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+            登録
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/components/BlogCards.tsx
+++ b/src/app/components/BlogCards.tsx
@@ -22,22 +22,22 @@ const BlogCards: React.FC<Props> = ({ blogs, onDelete }) => {
         <div key={blog.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{blog.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{blog.content}</p>
-          <div className="space-x-2">
+          <div className="flex justify-end space-x-2">
             <button
               onClick={() => router.push(`/blogs/${blog.id}`)}
-              className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+              className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600"
             >
               詳細
             </button>
             <button
               onClick={() => router.push(`/blogs/edit/${blog.id}`)}
-              className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
+              className="bg-green-500 text-white px-3 py-2 rounded hover:bg-green-600"
             >
               編集
             </button>
             <button
               onClick={() => handleDelete(blog.id)}
-              className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+              className="bg-red-500 text-white px-3 py-2 rounded hover:bg-red-600"
             >
               削除
             </button>

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -23,14 +23,14 @@ const DiaryCards: React.FC<Props> = ({ diaries, onDelete }) => {
         <div key={diary.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{diary.content}</p>
-          <div className="space-x-2">
-            <button onClick={() => router.push(`/diaries/${diary.id}`)} className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600">
+          <div className="flex justify-end space-x-2">
+            <button onClick={() => router.push(`/diaries/${diary.id}`)} className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600">
               詳細
             </button>
-            <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600">
+            <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-green-500 text-white px-3 py-2 rounded hover:bg-green-600">
               編集
             </button>
-            <button onClick={() => handleDelete(diary.id)} className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600">
+            <button onClick={() => handleDelete(diary.id)} className="bg-red-500 text-white px-3 py-2 rounded hover:bg-red-600">
               削除
             </button>
           </div>

--- a/src/app/components/PasswordCards.tsx
+++ b/src/app/components/PasswordCards.tsx
@@ -9,16 +9,18 @@ const PasswordCards: React.FC<Props> = ({ passwords }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {passwords.map((p) => (
-        <div key={p.id} className="border rounded p-4 bg-white shadow">
+        <div key={p.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{p.site_name}</h3>
           <p className="text-sm break-all mb-1">{p.site_url}</p>
           {p.login_id && <p className="text-sm break-all mb-1">{p.login_id}</p>}
-          <button
-            onClick={() => router.push(`/passwords/edit/${p.id}`)}
-            className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-          >
-            詳細
-          </button>
+          <div className="flex justify-end">
+            <button
+              onClick={() => router.push(`/passwords/edit/${p.id}`)}
+              className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600"
+            >
+              詳細
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -111,8 +111,8 @@ return (
               />
             </div>
             <div className="flex justify-end space-x-2 pt-2">
-              <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-1">キャンセル</button>
-              <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded">登録</button>
+              <button type="button" onClick={() => setIsOpen(false)} className="px-4 py-2">キャンセル</button>
+              <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
             </div>
           </form>
         </div>

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -20,7 +20,7 @@ const ThemeToggle = () => {
   };
 
   return (
-    <button onClick={toggle} className="ml-2 px-2 py-1 border rounded">
+    <button onClick={toggle} className="ml-2 px-2 py-2 border rounded">
       {isDark ? 'ライト' : 'ダーク'}
     </button>
   );

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -23,22 +23,22 @@ const WikiCards: React.FC<Props> = ({ wikis, onDelete }) => {
         <div key={wiki.id} className="border rounded p-4 bg-white shadow space-y-2">
           <h3 className="font-bold mb-2 truncate">{wiki.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{wiki.content}</p>
-          <div className="space-x-2">
+          <div className="flex justify-end space-x-2">
             <button
               onClick={() => router.push(`/wikis/${wiki.id}`)}
-              className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+              className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600"
             >
               詳細
             </button>
             <button
               onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
-              className="bg-green-500 text-white px-3 py-1 rounded hover:bg-green-600"
+              className="bg-green-500 text-white px-3 py-2 rounded hover:bg-green-600"
             >
               編集
             </button>
             <button
               onClick={() => handleDelete(wiki.id)}
-              className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+              className="bg-red-500 text-white px-3 py-2 rounded hover:bg-red-600"
             >
               削除
             </button>

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -37,9 +37,11 @@ const DiaryDetailPage = ({ params }: { params: { id: string } }) => {
           {diary.content}
         </ReactMarkdown>
       </div>
-      <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">
-        編集
-      </button>
+      <div className="flex justify-end">
+        <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">
+          編集
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/diaries/edit/[id]/page.tsx
+++ b/src/app/diaries/edit/[id]/page.tsx
@@ -64,7 +64,7 @@ const DiaryEditPage = ({ params }: { params: { id: string } }) => {
           <label className="block">内容</label>
           <textarea value={content} onChange={(e) => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
         </div>
-        <div className="space-x-2">
+        <div className="flex justify-end space-x-2">
           <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
           <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
         </div>

--- a/src/app/diaries/new/page.tsx
+++ b/src/app/diaries/new/page.tsx
@@ -33,7 +33,9 @@ const NewDiaryPage = () => {
           <label className="block">内容</label>
           <textarea value={content} onChange={(e) => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
         </div>
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+        <div className="flex justify-end">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -169,12 +169,14 @@ const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
             rows={6}
           />
         </div>
-        <button
-          type="submit"
-          className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
-        >
-          更新
-        </button>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            className="bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700"
+          >
+            更新
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/src/app/passwords/new/page.tsx
+++ b/src/app/passwords/new/page.tsx
@@ -116,7 +116,9 @@ const AddPassword: React.FC = () => {
                         onChange={handleChange}
                     ></textarea>
                 </div>
-                <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">登録</button>
+                <div className="flex justify-end">
+                    <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">登録</button>
+                </div>
             </form>
         </div>
     );

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -40,12 +40,14 @@ const WikiDetailPage = ({ params }: { params: { id: string } }) => {
           {wiki.content}
         </ReactMarkdown>
       </div>
-      <button
-        onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
-        className="bg-blue-500 text-white px-4 py-2 rounded"
-      >
-        編集
-      </button>
+      <div className="flex justify-end">
+        <button
+          onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          編集
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -64,7 +64,7 @@ const WikiEditPage = ({ params }: { params: { id: string } }) => {
           <label className="block">内容</label>
           <textarea value={content} onChange={e => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
         </div>
-        <div className="space-x-2">
+        <div className="flex justify-end space-x-2">
           <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
           <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
         </div>

--- a/src/app/wikis/new/page.tsx
+++ b/src/app/wikis/new/page.tsx
@@ -33,7 +33,9 @@ const NewWikiPage = () => {
           <label className="block">内容</label>
           <textarea value={content} onChange={e => setContent(e.target.value)} className="w-full border p-2 rounded" rows={6} required />
         </div>
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+        <div className="flex justify-end">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">登録</button>
+        </div>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- align button sections to right across pages
- unify button heights by switching to `py-2`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ef99edfc833285b14dee6bc9c5c3