### PR TITLE
Implement file upload for blog eyecatch images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 data/
+
+# uploaded images
+/public/uploads/*
+!/public/uploads/.gitkeep

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: 'File is required' }, { status: 400 });
+  }
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+  await fs.mkdir(uploadDir, { recursive: true });
+  const ext = path.extname(file.name);
+  const filename = `${crypto.randomUUID()}${ext}`;
+  await fs.writeFile(path.join(uploadDir, filename), buffer);
+  const url = `/uploads/${filename}`;
+  return NextResponse.json({ url });
+}

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -51,6 +51,20 @@ const BlogEditPage = ({ params }: { params: { id: string } }) => {
     setForm({ ...form, [name]: value });
   };
 
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/upload', { method: 'POST', body: formData });
+    if (res.ok) {
+      const data = await res.json();
+      setForm({ ...form, eyecatch: data.url });
+    } else {
+      alert('画像アップロード失敗');
+    }
+  };
+
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
     const res = await fetch(`/api/blog/${id}`, {
@@ -125,14 +139,16 @@ const BlogEditPage = ({ params }: { params: { id: string } }) => {
           />
         </div>
         <div>
-          <label className="block">アイキャッチ画像URL</label>
+          <label className="block">アイキャッチ画像</label>
           <input
-            name="eyecatch"
-            value={form.eyecatch}
-            onChange={handleChange}
+            type="file"
+            onChange={handleFileChange}
             className="w-full border p-2 rounded"
-            required
+            required={!form.eyecatch}
           />
+          {form.eyecatch && (
+            <p className="text-sm mt-1 text-gray-700">{form.eyecatch}</p>
+          )}
         </div>
         <div>
           <label className="block">パーマリンク</label>

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -24,6 +24,20 @@ const NewBlogPage = () => {
     setForm({ ...form, [name]: value });
   };
 
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/upload', { method: 'POST', body: formData });
+    if (res.ok) {
+      const data = await res.json();
+      setForm({ ...form, eyecatch: data.url });
+    } else {
+      alert('画像アップロード失敗');
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const res = await fetch('/api/blog', {
@@ -119,14 +133,16 @@ const NewBlogPage = () => {
           />
         </div>
         <div>
-          <label className="block">アイキャッチ画像URL</label>
+          <label className="block">アイキャッチ画像</label>
           <input
-            name="eyecatch"
-            value={form.eyecatch}
-            onChange={handleChange}
+            type="file"
+            onChange={handleFileChange}
             className="w-full border p-2 rounded"
-            required
+            required={!form.eyecatch}
           />
+          {form.eyecatch && (
+            <p className="text-sm mt-1 text-gray-700">{form.eyecatch}</p>
+          )}
         </div>
         <div>
           <label className="block">パーマリンク</label>


### PR DESCRIPTION
## Summary
- add `/api/upload` route that saves uploaded files under `public/uploads`
- update blog create/edit pages to upload eyecatch images instead of entering a URL
- ignore uploaded images in git

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6869f8975d308332a728104e7a338f6d