### PR TITLE
Implement basic file manager

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -72,6 +72,9 @@ const MainPage = () => {
         <Link href="/passwords/new" className="bg-green-500 text-white px-3 py-2 rounded">
           パスワード登録
         </Link>
+        <Link href="/files" className="bg-gray-500 text-white px-3 py-2 rounded">
+          ファイル管理
+        </Link>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const docsRoot = path.join(process.cwd(), 'public', 'docs');
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const relPath = searchParams.get('path') || '';
+  const target = path.join(docsRoot, relPath);
+  try {
+    const items = await fs.readdir(target, { withFileTypes: true });
+    const entries = items.map((d) => ({ name: d.name, isDirectory: d.isDirectory() }));
+    return NextResponse.json(entries);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to list files' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const relPath: string = body.path || '';
+    const name: string = body.name;
+    if (!name) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 });
+    }
+    await fs.mkdir(path.join(docsRoot, relPath, name), { recursive: true });
+    return NextResponse.json({ message: 'folder created' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to create folder' }, { status: 500 });
+  }
+}

--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const docsRoot = path.join(process.cwd(), 'public', 'docs');
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const file = formData.get('file');
+  const relPath = (formData.get('path') as string) || '';
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: 'File is required' }, { status: 400 });
+  }
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  await fs.mkdir(path.join(docsRoot, relPath), { recursive: true });
+  const ext = path.extname(file.name);
+  const filename = `${crypto.randomUUID()}${ext}`;
+  await fs.writeFile(path.join(docsRoot, relPath, filename), buffer);
+  const url = `/docs/${relPath ? relPath + '/' : ''}${filename}`;
+  return NextResponse.json({ url });
+}

--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { FileEntry } from '@/types/fileEntry';
+
+const FileManagerPage = () => {
+  const [path, setPath] = useState('');
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [folderName, setFolderName] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  const load = async (p: string) => {
+    const res = await fetch(`/api/files?path=${encodeURIComponent(p)}`);
+    if (res.ok) {
+      const data: FileEntry[] = await res.json();
+      setEntries(data);
+      setPath(p);
+    }
+  };
+
+  useEffect(() => {
+    load('');
+  }, []);
+
+  const goUp = () => {
+    const parts = path.split('/');
+    parts.pop();
+    const parent = parts.join('/');
+    load(parent);
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/files', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, name: folderName }),
+    });
+    if (res.ok) {
+      setFolderName('');
+      load(path);
+    } else {
+      alert('作成失敗');
+    }
+  };
+
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('path', path);
+    const res = await fetch('/api/files/upload', { method: 'POST', body: fd });
+    if (res.ok) {
+      setFile(null);
+      (e.target as HTMLFormElement).reset();
+      load(path);
+    } else {
+      alert('アップロード失敗');
+    }
+  };
+
+  const openDir = (name: string) => {
+    const newPath = path ? `${path}/${name}` : name;
+    load(newPath);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">ファイル管理</h1>
+      {path && (
+        <button onClick={goUp} className="text-blue-600 hover:underline">
+          上のフォルダへ
+        </button>
+      )}
+      <ul className="space-y-1">
+        {entries.map((e) => (
+          <li key={e.name}>
+            {e.isDirectory ? (
+              <button onClick={() => openDir(e.name)} className="text-blue-600 hover:underline">
+                {e.name}/
+              </button>
+            ) : (
+              <a href={`/docs/${path ? path + '/' : ''}${e.name}`} download className="text-blue-600 hover:underline">
+                {e.name}
+              </a>
+            )}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleCreate} className="space-x-2">
+        <input
+          value={folderName}
+          onChange={(e) => setFolderName(e.target.value)}
+          placeholder="フォルダ名"
+          className="border p-1"
+          required
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">
+          フォルダ作成
+        </button>
+      </form>
+      <form onSubmit={handleUpload} className="space-x-2">
+        <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1 rounded">
+          アップロード
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default FileManagerPage;

--- a/src/types/fileEntry.d.ts
+++ b/src/types/fileEntry.d.ts
@@ -1,0 +1,4 @@
+export type FileEntry = {
+  name: string;
+  isDirectory: boolean;
+};

--- a/tests/api/files.test.ts
+++ b/tests/api/files.test.ts
@@ -1,0 +1,50 @@
+import { GET, POST as CREATE } from '../../src/app/api/files/route';
+import { POST as UPLOAD } from '../../src/app/api/files/upload/route';
+import fs from 'fs/promises';
+import path from 'path';
+
+const docsRoot = path.join(process.cwd(), 'public', 'docs');
+
+describe('File API', () => {
+  const folder = 'jest-folder';
+
+  afterAll(async () => {
+    await fs.rm(path.join(docsRoot, folder), { recursive: true, force: true });
+  });
+
+  it('should list files', async () => {
+    const req = new Request('http://localhost/api/files');
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it('should create folder and upload file', async () => {
+    const createReq = new Request('http://localhost/api/files', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: '', name: folder }),
+    });
+    const createRes = await CREATE(createReq as any);
+    expect(createRes.status).toBe(200);
+
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('path', folder);
+    const uploadReq = new Request('http://localhost/api/files/upload', {
+      method: 'POST',
+      body: fd,
+    });
+    const uploadRes = await UPLOAD(uploadReq as any);
+    expect(uploadRes.status).toBe(200);
+    const { url } = await uploadRes.json();
+    const filePath = path.join(process.cwd(), 'public', url.replace(/^\//, ''));
+    const exists = await fs
+      .stat(filePath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add API routes for listing, folder creation, and uploading documents
- implement client-side file manager page
- expose FileEntry type and tests
- link to file manager from the main page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fab41de48332a4db0afd4b27e2de