### PR TITLE
Add schedule update and delete

### DIFF
--- a/src/app/api/schedule/[id]/route.ts
+++ b/src/app/api/schedule/[id]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Schedule } from '@/types/schedule';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid schedule ID.' }, { status: 400 });
+  }
+  try {
+    const row = runGet<Schedule>('SELECT * FROM schedules WHERE id = ?', [Number(id)]);
+    if (!row) {
+      return NextResponse.json({ error: 'schedule not found.' }, { status: 404 });
+    }
+    return NextResponse.json(row);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch schedule.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { title, start, end, memo } = body;
+    if (!title || !start || !end) {
+      return NextResponse.json({ error: 'required fields missing' }, { status: 400 });
+    }
+    runExecute('UPDATE schedules SET title = ?, start = ?, end = ?, memo = ? WHERE id = ?', [title, start, end, memo ?? null, Number(id)]);
+    return NextResponse.json({ message: 'schedule updated successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to update schedule.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM schedules WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'schedule deleted successfully.' });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete schedule.' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- allow editing and deleting schedules via new API route
- update calendar component UI for editing and deleting events
- cover update and delete in schedule API tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1c0b40ac8332ad056b5829bc5f6c