### PR TITLE
Fix invalid date handling for Google Calendar events

### DIFF
--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -45,10 +45,12 @@ const ScheduleCalendar = () => {
 
   const handleEventClick = (arg: EventClickArg) => {
     const e = arg.event;
+    const startDate = e.start instanceof Date && !isNaN(e.start.getTime()) ? e.start : undefined;
+    const endDate = e.end instanceof Date && !isNaN(e.end.getTime()) ? e.end : undefined;
     setForm({
       title: e.title,
-      start: format(e.start!, "yyyy-MM-dd'T'HH:mm"),
-      end: format(e.end!, "yyyy-MM-dd'T'HH:mm"),
+      start: startDate ? format(startDate, "yyyy-MM-dd'T'HH:mm") : '',
+      end: endDate ? format(endDate, "yyyy-MM-dd'T'HH:mm") : '',
       memo: (e.extendedProps.memo as string) || '',
     });
     setEditId(Number(e.id));

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -13,14 +13,21 @@ function getAuth() {
 export async function createEvent({ title, start, end, description }: { title: string; start: string; end: string; description?: string; }) {
   const auth = getAuth();
   const calendarId = process.env.GOOGLE_CALENDAR_ID as string;
+
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+    throw new Error('Invalid start or end date');
+  }
+
   const res = await calendar.events.insert({
     auth,
     calendarId,
     requestBody: {
       summary: title,
       description,
-      start: { dateTime: start },
-      end: { dateTime: end },
+      start: { dateTime: startDate.toISOString() },
+      end: { dateTime: endDate.toISOString() },
     },
   });
   return res.data.id;


### PR DESCRIPTION
## Summary
- validate and convert dates when creating Google Calendar events

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1ebf4a388332868dd857abdf142c