### PR TITLE
Fix page param usage and refine ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,12 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+/** @type {import('eslint').Linter.FlatConfig[]} */
 const eslintConfig = [
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["data/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import type { Blog } from '@/types/blog';
 
 const BlogDetailPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [blog, setBlog] = useState<Blog | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import type { Blog } from '@/types/blog';
 
 const BlogEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [form, setForm] = useState({
     title: '',

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -7,7 +7,7 @@ import rehypeHighlight from 'rehype-highlight';
 import type { Diary } from '@/types/diary';
 
 const DiaryDetailPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [diary, setDiary] = useState<Diary | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/diaries/edit/[id]/page.tsx
+++ b/src/app/diaries/edit/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import type { Diary } from '@/types/diary';
 
 const DiaryEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');

--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import type { Password } from '@/types/password';
 
 const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [idState] = useState<string>(id);
   const [siteName, setSiteName] = useState('');

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -7,7 +7,7 @@ import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
 const WikiDetailPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [wiki, setWiki] = useState<Wiki | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import type { Wiki } from '@/types/wiki';
 
 const WikiEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = React.use(params);
+  const { id } = params;
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');


### PR DESCRIPTION
## Summary
- enhance ESLint config with typed config and ignore `data` folder
- fix incorrect `React.use` calls in page components so the `id` parameter is read correctly

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a302c0ac08332a7c0d06fb79b59d8