### PR TITLE
Fix page props for dynamic routes

### DIFF
--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import type { Diary } from '@/types/diary';
 
-const DiaryDetailPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const DiaryDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [diary, setDiary] = useState<Diary | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/diaries/edit/[id]/page.tsx
+++ b/src/app/diaries/edit/[id]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 import React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import type { Diary } from '@/types/diary';
 
-const DiaryEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const DiaryEditPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');

--- a/src/app/expenses/edit/[id]/page.tsx
+++ b/src/app/expenses/edit/[id]/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import type { Expense } from '@/types/expense';
 
-const ExpenseEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const ExpenseEditPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [form, setForm] = useState<{
     category: string;

--- a/src/app/passwords/edit/[id]/page.tsx
+++ b/src/app/passwords/edit/[id]/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { Password } from '@/types/password';
 
-const UpdatePasswordPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const UpdatePasswordPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [idState] = useState<string>(id);
   const [siteName, setSiteName] = useState('');

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
-const WikiDetailPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const WikiDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [wiki, setWiki] = useState<Wiki | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/app/wikis/edit/[id]/page.tsx
+++ b/src/app/wikis/edit/[id]/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 import React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import type { Wiki } from '@/types/wiki';
 
-const WikiEditPage = ({ params }: { params: { id: string } }) => {
-  const { id } = params;
+const WikiEditPage = () => {
+  const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');


### PR DESCRIPTION
## Summary
- use `useParams` in client-side pages under `[id]` routes

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a3a96a5d48332b58308c101b28479