### PR TITLE
Fix TypeScript type mismatch in schedule API

### DIFF
--- a/src/app/api/schedule/route.ts
+++ b/src/app/api/schedule/route.ts
@@ -24,9 +24,9 @@ export async function POST(req: Request) {
       'INSERT INTO schedules (title, start, end, memo) VALUES (?, ?, ?, ?)'
     );
     const info = stmt.run(title, start, end, memo);
-    let googleId: string | undefined;
+    let googleId: string | null = null;
     try {
-      googleId = await createEvent({ title, start, end, description: memo });
+      googleId = (await createEvent({ title, start, end, description: memo })) ?? null;
       db.prepare('UPDATE schedules SET google_event_id = ? WHERE id = ?').run(
         googleId,
         info.lastInsertRowid


### PR DESCRIPTION
## Summary
- handle null from Google Calendar event creation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails with many missing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a3c26b40883329c3bad7e353f47b9