### PR TITLE
Fix FullCalendar EventInput import

### DIFF
--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import FullCalendar, { EventInput } from '@fullcalendar/react';
+import FullCalendar from '@fullcalendar/react';
+import { EventInput } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { DateClickArg, EventClickArg } from '@fullcalendar/interaction';
 import { format } from 'date-fns';


### PR DESCRIPTION
## Summary
- update ScheduleCalendar to import `EventInput` from `@fullcalendar/core`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3d8ea71483329121e412e1f47ffa