### PR TITLE
Fix search page pre-render error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import React from 'react';
+import React, { Suspense } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import ThemeToggle from './components/ThemeToggle';
@@ -36,7 +36,9 @@ const RootLayout = ({
         </header>
 
         <main className="flex-grow p-6 overflow-auto mt-16 mb-16">
-          {children}
+          <Suspense fallback={<div>Loading...</div>}>
+            {children}
+          </Suspense>
         </main>
 
         <footer className="bg-gray-700 text-white py-4 px-6 fixed bottom-0 w-full z-10">


### PR DESCRIPTION
## Summary
- use Suspense around layout children to satisfy `useSearchParams` requirements

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4461e2f88332bc8b02d4bdeb1cf5