### PR TITLE
Fix missing File global in API routes

### DIFF
--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+// Node 18 and later expose a File implementation via the `buffer` module.
+// Explicitly importing it ensures compatibility when the global `File`
+// class is not automatically available (e.g. on older Node versions).
+import { File } from 'buffer';
 
 const docsRoot = path.join(process.cwd(), 'public', 'docs');
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { File } from 'buffer';
 
 export async function POST(request: Request) {
   const formData = await request.formData();


### PR DESCRIPTION
## Summary
- import `File` from `buffer` so server routes have access to the `File` class

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a51c1c2c883328957f8f415afb63f