### PR TITLE
Fix file uploads using original names

### DIFF
--- a/src/app/api/files/upload/route.ts
+++ b/src/app/api/files/upload/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
-import crypto from 'crypto';
 // Node 18 and later expose a File implementation via the `buffer` module.
 // Explicitly importing it ensures compatibility when the global `File`
 // class is not automatically available (e.g. on older Node versions).
@@ -19,8 +18,7 @@ export async function POST(request: Request) {
   const bytes = await file.arrayBuffer();
   const buffer = Buffer.from(bytes);
   await fs.mkdir(path.join(docsRoot, relPath), { recursive: true });
-  const ext = path.extname(file.name);
-  const filename = `${crypto.randomUUID()}${ext}`;
+  const filename = path.basename(file.name);
   await fs.writeFile(path.join(docsRoot, relPath, filename), buffer);
   const url = `/docs/${relPath ? relPath + '/' : ''}${filename}`;
   return NextResponse.json({ url });

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -13,8 +13,7 @@ export async function POST(request: Request) {
   const buffer = Buffer.from(bytes);
   const uploadDir = path.join(process.cwd(), 'public', 'uploads');
   await fs.mkdir(uploadDir, { recursive: true });
-  const ext = path.extname(file.name);
-  const filename = `${crypto.randomUUID()}${ext}`;
+  const filename = path.basename(file.name);
   await fs.writeFile(path.join(uploadDir, filename), buffer);
   const url = `/uploads/${filename}`;
   return NextResponse.json({ url });


### PR DESCRIPTION
## Summary
- preserve uploaded file names instead of UUID

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a54dfe8708332abf7b456c6431551