### PR TITLE
Improve list page layout

### DIFF
--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -28,8 +28,14 @@ const BlogListPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">ブログ一覧</h1>
-      <Link href="/blogs/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
-      <ul className="space-y-2">
+      <div className="flex flex-wrap justify-end gap-2 my-4">
+        <Link href="/blogs/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
+        <Link href="/authors/new" className="bg-green-500 text-white px-4 py-2 rounded">著者登録</Link>
+        <Link href="/authors" className="bg-green-500 text-white px-4 py-2 rounded">著者一覧</Link>
+        <Link href="/personas/new" className="bg-purple-500 text-white px-4 py-2 rounded">ペルソナ登録</Link>
+        <Link href="/personas" className="bg-purple-500 text-white px-4 py-2 rounded">ペルソナ一覧</Link>
+      </div>
+      <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {blogs.map((blog) => (
           <li key={blog.id} className="border p-4 rounded space-y-2">
             <Link href={`/blogs/${blog.id}`} className="font-semibold hover:underline block">

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -30,8 +30,12 @@ const DiaryListPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">日報一覧</h1>
-      <Link href="/diaries/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
-      <ul className="space-y-2">
+      <div className="flex justify-end my-4">
+        <Link href="/diaries/new" className="bg-blue-500 text-white px-4 py-2 rounded">
+          新規作成
+        </Link>
+      </div>
+      <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {diaries.map((diary) => (
           <li key={diary.id} className="border p-4 rounded space-y-2">
             <Link href={`/diaries/${diary.id}`} className="font-semibold hover:underline block">

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -30,8 +30,12 @@ const WikiListPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Wiki一覧</h1>
-      <Link href="/wikis/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
-      <ul className="space-y-2">
+      <div className="flex justify-end my-4">
+        <Link href="/wikis/new" className="bg-blue-500 text-white px-4 py-2 rounded">
+          新規作成
+        </Link>
+      </div>
+      <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {wikis.map((wiki) => (
           <li key={wiki.id} className="border p-4 rounded space-y-2">
             <Link


### PR DESCRIPTION
## Summary
- show 3-column grid for Wiki, Diary and Blog lists
- right-align create buttons with vertical margin
- add Author/Persona registration & list links to Blog page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7530263083328682438cce0ee4b1