### PR TITLE
Add edit/delete for authors and personas

### DIFF
--- a/src/app/api/author/[id]/route.ts
+++ b/src/app/api/author/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Author } from '@/types/author';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid author ID.' }, { status: 400 });
+  }
+  try {
+    const result = runGet<Author>('SELECT * FROM author WHERE id = ?', [Number(id)]);
+    if (!result) {
+      return NextResponse.json({ error: 'author not found.' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to fetch author.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { name, bio } = body;
+    if (!name) {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 });
+    }
+    runExecute('UPDATE author SET name = ?, bio = ? WHERE id = ?', [name, bio ?? null, Number(id)]);
+    return NextResponse.json({ message: 'author updated successfully.' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to update author.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM author WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'author deleted successfully.' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to delete author.' }, { status: 500 });
+  }
+}

--- a/src/app/api/persona/[id]/route.ts
+++ b/src/app/api/persona/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { runGet, runExecute } from '@/lib/db';
+import type { Persona } from '@/types/persona';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!id || isNaN(Number(id))) {
+    return NextResponse.json({ error: 'Invalid persona ID.' }, { status: 400 });
+  }
+  try {
+    const result = runGet<Persona>('SELECT * FROM persona WHERE id = ?', [Number(id)]);
+    if (!result) {
+      return NextResponse.json({ error: 'persona not found.' }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to fetch persona.' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const { name, description } = body;
+    if (!name) {
+      return NextResponse.json({ error: 'name is required.' }, { status: 400 });
+    }
+    runExecute('UPDATE persona SET name = ?, description = ? WHERE id = ?', [name, description ?? null, Number(id)]);
+    return NextResponse.json({ message: 'persona updated successfully.' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to update persona.' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    runExecute('DELETE FROM persona WHERE id = ?', [Number(id)]);
+    return NextResponse.json({ message: 'persona deleted successfully.' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to delete persona.' }, { status: 500 });
+  }
+}

--- a/src/app/authors/edit/[id]/page.tsx
+++ b/src/app/authors/edit/[id]/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import type { Author } from '@/types/author';
+
+const AuthorEditPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [bio, setBio] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/author/${id}`);
+        if (res.ok) {
+          const data: Author = await res.json();
+          setName(data.name);
+          setBio(data.bio ?? '');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/author/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, bio }),
+    });
+    if (res.ok) {
+      router.push('/authors');
+    } else {
+      alert('更新失敗');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/author/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/authors');
+    } else {
+      alert('削除失敗');
+    }
+  };
+
+  if (loading) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">著者編集</h1>
+      <form onSubmit={handleUpdate} className="space-y-2">
+        <div>
+          <label className="block">名前</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">Bio</label>
+          <textarea
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            className="w-full border p-2 rounded"
+            rows={4}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
+          <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default AuthorEditPage;

--- a/src/app/authors/page.tsx
+++ b/src/app/authors/page.tsx
@@ -21,6 +21,16 @@ const AuthorListPage = () => {
     load();
   }, []);
 
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/author/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      setAuthors(authors!.filter((a) => a.id !== id));
+    } else {
+      alert('削除失敗');
+    }
+  };
+
   if (error) return <div>読み込みエラー</div>;
   if (!authors) return <div>読み込み中...</div>;
 
@@ -30,9 +40,17 @@ const AuthorListPage = () => {
       <Link href="/authors/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
       <ul className="space-y-2">
         {authors.map((a) => (
-          <li key={a.id} className="border p-2 rounded">
+          <li key={a.id} className="border p-2 rounded space-y-1">
             <p className="font-semibold">{a.name}</p>
             {a.bio && <p className="text-sm">{a.bio}</p>}
+            <div className="space-x-2">
+              <Link href={`/authors/edit/${a.id}`} className="bg-green-500 text-white px-2 py-1 rounded">
+                編集
+              </Link>
+              <button onClick={() => handleDelete(a.id)} className="bg-red-500 text-white px-2 py-1 rounded">
+                削除
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/src/app/personas/edit/[id]/page.tsx
+++ b/src/app/personas/edit/[id]/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import type { Persona } from '@/types/persona';
+
+const PersonaEditPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/persona/${id}`);
+        if (res.ok) {
+          const data: Persona = await res.json();
+          setName(data.name);
+          setDescription(data.description ?? '');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/persona/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, description }),
+    });
+    if (res.ok) {
+      router.push('/personas');
+    } else {
+      alert('更新失敗');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/persona/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/personas');
+    } else {
+      alert('削除失敗');
+    }
+  };
+
+  if (loading) return <div>読み込み中...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">ペルソナ編集</h1>
+      <form onSubmit={handleUpdate} className="space-y-2">
+        <div>
+          <label className="block">名前</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full border p-2 rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block">詳細</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="w-full border p-2 rounded"
+            rows={4}
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">更新</button>
+          <button type="button" onClick={handleDelete} className="bg-red-500 text-white px-4 py-2 rounded">削除</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default PersonaEditPage;

--- a/src/app/personas/page.tsx
+++ b/src/app/personas/page.tsx
@@ -21,6 +21,16 @@ const PersonaListPage = () => {
     load();
   }, []);
 
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    const res = await fetch(`/api/persona/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      setPersonas(personas!.filter((p) => p.id !== id));
+    } else {
+      alert('削除失敗');
+    }
+  };
+
   if (error) return <div>読み込みエラー</div>;
   if (!personas) return <div>読み込み中...</div>;
 
@@ -30,9 +40,17 @@ const PersonaListPage = () => {
       <Link href="/personas/new" className="bg-blue-500 text-white px-4 py-2 rounded">新規作成</Link>
       <ul className="space-y-2">
         {personas.map((p) => (
-          <li key={p.id} className="border p-2 rounded">
+          <li key={p.id} className="border p-2 rounded space-y-1">
             <p className="font-semibold">{p.name}</p>
             {p.description && <p className="text-sm">{p.description}</p>}
+            <div className="space-x-2">
+              <Link href={`/personas/edit/${p.id}`} className="bg-green-500 text-white px-2 py-1 rounded">
+                編集
+              </Link>
+              <button onClick={() => handleDelete(p.id)} className="bg-red-500 text-white px-2 py-1 rounded">
+                削除
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/tests/api/author.test.ts
+++ b/tests/api/author.test.ts
@@ -1,9 +1,18 @@
 import { GET, POST } from '../../src/app/api/author/route';
+import { GET as GET_ID, PUT, DELETE } from '../../src/app/api/author/[id]/route';
 import { runSelect, runExecute } from '../../src/lib/db';
 
 function createPostRequest(body: any) {
   return new Request('http://localhost/api/author', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function createPutRequest(id: number, body: any) {
+  return new Request(`http://localhost/api/author/${id}`, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -41,5 +50,33 @@ describe('POST /api/author', () => {
     const req = createPostRequest({});
     const res = await POST(req as any);
     expect(res.status).toBe(400);
+  });
+});
+
+describe('Author update and delete', () => {
+  const entry = { name: 'jest2', bio: 'bio' };
+  let id: number;
+
+  afterAll(() => {
+    if (id) runExecute('DELETE FROM author WHERE id = ?', [id]);
+  });
+
+  it('should create entry then update and delete', async () => {
+    const createReq = createPostRequest(entry);
+    const createRes = await POST(createReq as any);
+    expect(createRes.status).toBe(200);
+    const row = runSelect('SELECT * FROM author WHERE name = ?', [entry.name])[0];
+    id = row.id;
+
+    const updateReq = createPutRequest(id, { name: 'updated', bio: 'b' });
+    const updateRes = await PUT(updateReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(updateRes.status).toBe(200);
+
+    const deleteReq = new Request(`http://localhost/api/author/${id}`, { method: 'DELETE' });
+    const deleteRes = await DELETE(deleteReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(deleteRes.status).toBe(200);
+
+    const rows = runSelect('SELECT * FROM author WHERE id = ?', [id]);
+    expect(rows.length).toBe(0);
   });
 });

--- a/tests/api/persona.test.ts
+++ b/tests/api/persona.test.ts
@@ -1,9 +1,18 @@
 import { GET, POST } from '../../src/app/api/persona/route';
+import { GET as GET_ID, PUT, DELETE } from '../../src/app/api/persona/[id]/route';
 import { runSelect, runExecute } from '../../src/lib/db';
 
 function createPostRequest(body: any) {
   return new Request('http://localhost/api/persona', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function createPutRequest(id: number, body: any) {
+  return new Request(`http://localhost/api/persona/${id}`, {
+    method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
@@ -41,5 +50,33 @@ describe('POST /api/persona', () => {
     const req = createPostRequest({});
     const res = await POST(req as any);
     expect(res.status).toBe(400);
+  });
+});
+
+describe('Persona update and delete', () => {
+  const entry = { name: 'jest2', description: 'd' };
+  let id: number;
+
+  afterAll(() => {
+    if (id) runExecute('DELETE FROM persona WHERE id = ?', [id]);
+  });
+
+  it('should create entry then update and delete', async () => {
+    const createReq = createPostRequest(entry);
+    const createRes = await POST(createReq as any);
+    expect(createRes.status).toBe(200);
+    const row = runSelect('SELECT * FROM persona WHERE name = ?', [entry.name])[0];
+    id = row.id;
+
+    const updateReq = createPutRequest(id, { name: 'up', description: 'd2' });
+    const updateRes = await PUT(updateReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(updateRes.status).toBe(200);
+
+    const deleteReq = new Request(`http://localhost/api/persona/${id}`, { method: 'DELETE' });
+    const deleteRes = await DELETE(deleteReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
+    expect(deleteRes.status).toBe(200);
+
+    const rows = runSelect('SELECT * FROM persona WHERE id = ?', [id]);
+    expect(rows.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- implement API routes for authors and personas with GET/PUT/DELETE
- add edit pages for authors and personas
- extend listing pages with edit/delete buttons
- add tests for update and delete

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afe746d3c8332b411f031f8d16f3c