### PR TITLE
Implement sticky note design for Wiki cards

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -125,10 +125,7 @@ const MainPage = () => {
             {errors.wikis ? (
               <p className="text-red-500">{errors.wikis}</p>
             ) : wikis.length > 0 ? (
-              <WikiCards
-                wikis={wikis}
-                onDelete={(id) => setWikis(wikis.filter((w) => w.id !== id))}
-              />
+              <WikiCards wikis={wikis} />
             ) : (
               <p className="text-gray-500">登録されたWikiがありません。</p>
             )}

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -2,47 +2,23 @@
 import type { Wiki } from '@/types/wiki';
 import { useRouter } from 'next/navigation';
 
-type Props = { wikis: Wiki[]; onDelete?: (id: number) => void };
+type Props = { wikis: Wiki[] };
 
-const WikiCards: React.FC<Props> = ({ wikis, onDelete }) => {
+const WikiCards: React.FC<Props> = ({ wikis }) => {
   const router = useRouter();
-
-  const handleDelete = async (id: number) => {
-    if (!confirm('削除しますか？')) return;
-    const res = await fetch(`/api/wiki/${id}`, { method: 'DELETE' });
-    if (res.ok) {
-      onDelete?.(id);
-    } else {
-      alert('削除失敗');
-    }
-  };
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {wikis.map((wiki) => (
-        <div key={wiki.id} className="border rounded p-4 bg-white shadow space-y-2">
-          <h3 className="font-bold mb-2 truncate">{wiki.title}</h3>
-          <p className="line-clamp-3 text-sm whitespace-pre-wrap">{wiki.content}</p>
-          <div className="flex justify-end space-x-2">
-            <button
-              onClick={() => router.push(`/wikis/${wiki.id}`)}
-              className="bg-blue-500 text-white px-3 py-2 rounded hover:bg-blue-600"
-            >
-              詳細
-            </button>
-            <button
-              onClick={() => router.push(`/wikis/edit/${wiki.id}`)}
-              className="bg-green-500 text-white px-3 py-2 rounded hover:bg-green-600"
-            >
-              編集
-            </button>
-            <button
-              onClick={() => handleDelete(wiki.id)}
-              className="bg-red-500 text-white px-3 py-2 rounded hover:bg-red-600"
-            >
-              削除
-            </button>
-          </div>
+        <div
+          key={wiki.id}
+          className="sticky-note cursor-pointer"
+          onClick={() => router.push(`/wikis/${wiki.id}`)}
+        >
+          <span className="sticky-note-title truncate">{wiki.title}</span>
+          <span className="sticky-note-date">
+            {new Date(wiki.created_at).toLocaleDateString('ja-JP')}
+          </span>
         </div>
       ))}
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,3 +43,37 @@ body {
 .markdown-body pre {
   @apply bg-gray-800 text-white p-4 rounded-md overflow-x-auto;
 }
+
+/* Sticky note style for wiki cards */
+.sticky-note {
+  background: #fff9c4;
+  border: 1px solid #fce089;
+  border-radius: 4px;
+  padding: 1rem;
+  position: relative;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.sticky-note::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 16px;
+  background: #f87171;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.sticky-note-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+.sticky-note-date {
+  font-size: 0.875rem;
+  color: #555555;
+}

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeHighlight from 'rehype-highlight';
 import type { Wiki } from '@/types/wiki';
 
 const WikiListPage = () => {
@@ -37,21 +34,13 @@ const WikiListPage = () => {
       </div>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {wikis.map((wiki) => (
-          <li key={wiki.id} className="border p-4 rounded space-y-2">
-            <Link
-              href={`/wikis/${wiki.id}`}
-              className="font-semibold hover:underline block"
-            >
+          <li key={wiki.id} className="sticky-note">
+            <Link href={`/wikis/${wiki.id}`} className="sticky-note-title block">
               {wiki.title}
             </Link>
-            <div className="markdown-body line-clamp-3 text-sm">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeHighlight]}
-              >
-                {wiki.content}
-              </ReactMarkdown>
-            </div>
+            <span className="sticky-note-date">
+              {new Date(wiki.created_at).toLocaleDateString('ja-JP')}
+            </span>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add sticky note styles in global CSS
- update wiki list page to display notes with created dates
- simplify WikiCards component to use sticky note design
- adjust main page to updated WikiCards API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc5322c008332be12fefe855eaaed