### PR TITLE
Adjust wiki cards on home page

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -47,7 +47,7 @@ const MainPage = () => {
     const loadData = async () => {
       await Promise.all([
         fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
-        fetchData<Wiki[]>('/api/wiki?limit=2', setWikis, 'wikis'),
+        fetchData<Wiki[]>('/api/wiki?limit=5', setWikis, 'wikis'),
         fetchData<Diary[]>('/api/diary?limit=2', setDiaries, 'diaries'),
         fetchData<Blog[]>('/api/blog?limit=2', setBlogs, 'blogs'),
       ]);

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -8,7 +8,7 @@ const WikiCards: React.FC<Props> = ({ wikis }) => {
   const router = useRouter();
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
       {wikis.map((wiki) => (
         <div
           key={wiki.id}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,7 +49,7 @@ body {
   background: #fff9c4;
   border: 1px solid #fce089;
   border-radius: 4px;
-  padding: 1rem;
+  padding: 0.5rem;
   position: relative;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## Summary
- show up to five wiki cards on the top page
- tweak wiki note grid layout
- reduce sticky note padding to fit five notes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcf8371c88332bc7183957934ca53