### PR TITLE
Add optional product and remark to expense records

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ CREATE TABLE expenses (
   category TEXT NOT NULL,
   amount INTEGER NOT NULL,
   shop TEXT NOT NULL,
+  product_name TEXT,
+  remark TEXT,
   used_at TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -62,6 +62,8 @@ db.exec(`
     category TEXT NOT NULL,
     amount INTEGER NOT NULL,
     shop TEXT NOT NULL,
+    product_name TEXT,
+    remark TEXT,
     used_at TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );

--- a/src/app/api/expense/[id]/route.ts
+++ b/src/app/api/expense/[id]/route.ts
@@ -23,13 +23,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   const { id } = await params;
   try {
     const body = await request.json();
-    const { category, amount, shop, used_at } = body;
+    const { category, amount, shop, used_at, product_name, remark } = body;
     if (!category || !amount || !shop || !used_at) {
       return NextResponse.json({ error: 'required fields missing' }, { status: 400 });
     }
     runExecute(
-      'UPDATE expenses SET category = ?, amount = ?, shop = ?, used_at = ? WHERE id = ?',
-      [category, Number(amount), shop, used_at, Number(id)]
+      'UPDATE expenses SET category = ?, amount = ?, shop = ?, used_at = ?, product_name = ?, remark = ? WHERE id = ?',
+      [category, Number(amount), shop, used_at, product_name ?? null, remark ?? null, Number(id)]
     );
     return NextResponse.json({ message: 'expense updated successfully.' });
   } catch (error) {

--- a/src/app/api/expense/route.ts
+++ b/src/app/api/expense/route.ts
@@ -26,13 +26,13 @@ export async function GET(request: Request) {
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { category, amount, shop, used_at } = body;
+    const { category, amount, shop, used_at, product_name, remark } = body;
     if (!category || !amount || !shop || !used_at) {
       return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
     }
     runExecute(
-      'INSERT INTO expenses (category, amount, shop, used_at) VALUES (?, ?, ?, ?)',
-      [category, Number(amount), shop, used_at]
+      'INSERT INTO expenses (category, amount, shop, used_at, product_name, remark) VALUES (?, ?, ?, ?, ?, ?)',
+      [category, Number(amount), shop, used_at, product_name ?? null, remark ?? null]
     );
     return NextResponse.json({ message: '登録成功' });
   } catch (error) {

--- a/src/app/components/WikiCards.tsx
+++ b/src/app/components/WikiCards.tsx
@@ -8,7 +8,7 @@ const WikiCards: React.FC<Props> = ({ wikis }) => {
   const router = useRouter();
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+    <div className="grid grid-cols-5 gap-2">
       {wikis.map((wiki) => (
         <div
           key={wiki.id}

--- a/src/app/expenses/edit/[id]/page.tsx
+++ b/src/app/expenses/edit/[id]/page.tsx
@@ -10,8 +10,10 @@ const ExpenseEditPage = () => {
     category: string;
     amount: string;
     shop: string;
+    product_name: string | null;
+    remark: string | null;
     used_at: string;
-  }>({ category: '', amount: '', shop: '', used_at: '' });
+  }>({ category: '', amount: '', shop: '', product_name: '', remark: '', used_at: '' });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -23,6 +25,8 @@ const ExpenseEditPage = () => {
           category: data.category,
           amount: String(data.amount),
           shop: data.shop,
+          product_name: data.product_name ?? '',
+          remark: data.remark ?? '',
           used_at: data.used_at,
         });
       }
@@ -40,6 +44,8 @@ const ExpenseEditPage = () => {
         category: form.category,
         amount: Number(form.amount),
         shop: form.shop,
+        product_name: form.product_name,
+        remark: form.remark,
         used_at: form.used_at,
       }),
     });
@@ -77,6 +83,23 @@ const ExpenseEditPage = () => {
         <div>
           <label className="block">お店</label>
           <input value={form.shop} onChange={(e) => setForm({ ...form, shop: e.target.value })} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">商品名</label>
+          <input
+            value={form.product_name ?? ''}
+            onChange={(e) => setForm({ ...form, product_name: e.target.value })}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block">備考</label>
+          <textarea
+            value={form.remark ?? ''}
+            onChange={(e) => setForm({ ...form, remark: e.target.value })}
+            className="w-full border p-2 rounded"
+            rows={3}
+          />
         </div>
         <div>
           <label className="block">使った日</label>

--- a/src/app/expenses/new/page.tsx
+++ b/src/app/expenses/new/page.tsx
@@ -7,6 +7,8 @@ const NewExpensePage = () => {
   const [category, setCategory] = useState('');
   const [amount, setAmount] = useState('');
   const [shop, setShop] = useState('');
+  const [productName, setProductName] = useState('');
+  const [remark, setRemark] = useState('');
   const [usedAt, setUsedAt] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -14,7 +16,14 @@ const NewExpensePage = () => {
     const res = await fetch('/api/expense', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ category, amount: Number(amount), shop, used_at: usedAt }),
+      body: JSON.stringify({
+        category,
+        amount: Number(amount),
+        shop,
+        used_at: usedAt,
+        product_name: productName || null,
+        remark: remark || null,
+      }),
     });
     if (res.ok) {
       router.push('/expenses');
@@ -38,6 +47,23 @@ const NewExpensePage = () => {
         <div>
           <label className="block">お店</label>
           <input value={shop} onChange={(e) => setShop(e.target.value)} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block">商品名</label>
+          <input
+            value={productName}
+            onChange={(e) => setProductName(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block">備考</label>
+          <textarea
+            value={remark}
+            onChange={(e) => setRemark(e.target.value)}
+            className="w-full border p-2 rounded"
+            rows={3}
+          />
         </div>
         <div>
           <label className="block">使った日</label>

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -46,6 +46,8 @@ const ExpenseListPage = () => {
             <th className="px-2 py-1 border">勘定科目</th>
             <th className="px-2 py-1 border">金額</th>
             <th className="px-2 py-1 border">お店</th>
+            <th className="px-2 py-1 border">商品名</th>
+            <th className="px-2 py-1 border">備考</th>
             <th className="px-2 py-1 border">操作</th>
           </tr>
         </thead>
@@ -56,6 +58,8 @@ const ExpenseListPage = () => {
               <td className="px-2 py-1 border">{e.category}</td>
               <td className="px-2 py-1 border text-right">¥{e.amount}</td>
               <td className="px-2 py-1 border">{e.shop}</td>
+              <td className="px-2 py-1 border">{e.product_name}</td>
+              <td className="px-2 py-1 border whitespace-pre-wrap">{e.remark}</td>
               <td className="px-2 py-1 border text-center space-x-2">
                 <button onClick={() => location.href=`/expenses/edit/${e.id}`} className="bg-green-500 text-white px-2 py-1 rounded">編集</button>
                 <button onClick={() => handleDelete(e.id)} className="bg-red-500 text-white px-2 py-1 rounded">削除</button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,9 +49,11 @@ body {
   background: #fff9c4;
   border: 1px solid #fce089;
   border-radius: 4px;
-  padding: 0.5rem;
+  padding: 0.25rem;
   position: relative;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+  font-size: 0.875rem;
+  width: 100%;
 }
 
 .sticky-note::before {

--- a/src/types/expense.d.ts
+++ b/src/types/expense.d.ts
@@ -3,6 +3,8 @@ export type Expense = {
   category: string;
   amount: number;
   shop: string;
+  product_name?: string | null;
+  remark?: string | null;
   used_at: string;
   created_at: string;
 };

--- a/tests/api/expense.test.ts
+++ b/tests/api/expense.test.ts
@@ -31,7 +31,7 @@ describe('GET /api/expense', () => {
 });
 
 describe('POST /api/expense', () => {
-  const entry = { category: 'jest', amount: 123, shop: 'store', used_at: '2099-01-01' };
+  const entry = { category: 'jest', amount: 123, shop: 'store', used_at: '2099-01-01', product_name: 'item', remark: 'memo' };
   afterAll(() => {
     runExecute('DELETE FROM expenses WHERE category = ?', [entry.category]);
   });
@@ -55,7 +55,7 @@ describe('POST /api/expense', () => {
 });
 
 describe('Expense update and delete', () => {
-  const entry = { category: 'jest2', amount: 100, shop: 'shop', used_at: '2099-01-02' };
+  const entry = { category: 'jest2', amount: 100, shop: 'shop', used_at: '2099-01-02', product_name: 'item2', remark: 'memo2' };
   let id: number;
   afterAll(() => {
     runExecute('DELETE FROM expenses WHERE id = ?', [id]);
@@ -68,9 +68,14 @@ describe('Expense update and delete', () => {
     const row = runSelect('SELECT * FROM expenses WHERE category = ?', [entry.category])[0];
     id = row.id;
 
-    const updateReq = createPutRequest(id, { ...entry, category: 'up' });
+    const updateReq = createPutRequest(id, { ...entry, category: 'up', product_name: 'updated', remark: 'updated memo' });
     const updateRes = await PUT(updateReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
     expect(updateRes.status).toBe(200);
+
+    const updatedRow = runSelect('SELECT * FROM expenses WHERE id = ?', [id])[0];
+    expect(updatedRow.category).toBe('up');
+    expect(updatedRow.product_name).toBe('updated');
+    expect(updatedRow.remark).toBe('updated memo');
 
     const deleteReq = new Request(`http://localhost/api/expense/${id}`, { method: 'DELETE' });
     const deleteRes = await DELETE(deleteReq as any, { params: Promise.resolve({ id: String(id) }) } as any);


### PR DESCRIPTION
## Summary
- expand `expenses` table with `product_name` and `remark`
- support new fields in API routes and types
- expose fields in create/edit forms and list view
- shrink wiki sticky notes and display five notes
- adjust documentation and tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3191e1a883329907fc312462571c