### PR TITLE
Increase wiki card columns

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,3 +79,8 @@ body {
   font-size: 0.875rem;
   color: #555555;
 }
+
+/* Grid layout for wiki list */
+.wiki-grid {
+  @apply grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-4;
+}

--- a/src/app/wikis/page.tsx
+++ b/src/app/wikis/page.tsx
@@ -32,7 +32,7 @@ const WikiListPage = () => {
           新規作成
         </Link>
       </div>
-      <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <ul className="wiki-grid">
         {wikis.map((wiki) => (
           <li key={wiki.id} className="sticky-note">
             <Link href={`/wikis/${wiki.id}`} className="sticky-note-title block">


### PR DESCRIPTION
## Summary
- show wiki list with 8 columns on large displays
- add `.wiki-grid` style with responsive grid settings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c86ace1f48332843f7adbdc69f257