### PR TITLE
Fix text visibility in dark mode

### DIFF
--- a/src/app/components/BlogCards.tsx
+++ b/src/app/components/BlogCards.tsx
@@ -19,7 +19,10 @@ const BlogCards: React.FC<Props> = ({ blogs, onDelete }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {blogs.map((blog) => (
-        <div key={blog.id} className="border rounded p-4 bg-white shadow space-y-2">
+        <div
+          key={blog.id}
+          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2"
+        >
           <h3 className="font-bold mb-2 truncate">{blog.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{blog.content}</p>
           <div className="flex justify-end space-x-2">

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -20,7 +20,10 @@ const DiaryCards: React.FC<Props> = ({ diaries, onDelete }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       {diaries.map((diary) => (
-        <div key={diary.id} className="border rounded p-4 bg-white shadow space-y-2">
+        <div
+          key={diary.id}
+          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2"
+        >
           <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{diary.content}</p>
           <div className="flex justify-end space-x-2">

--- a/src/app/components/PasswordCards.tsx
+++ b/src/app/components/PasswordCards.tsx
@@ -9,7 +9,10 @@ const PasswordCards: React.FC<Props> = ({ passwords }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {passwords.map((p) => (
-        <div key={p.id} className="border rounded p-4 bg-white shadow space-y-2">
+        <div
+          key={p.id}
+          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2"
+        >
           <h3 className="font-bold mb-2 truncate">{p.site_name}</h3>
           <p className="text-sm break-all mb-1">{p.site_url}</p>
           {p.login_id && <p className="text-sm break-all mb-1">{p.login_id}</p>}

--- a/src/app/components/PasswordList.tsx
+++ b/src/app/components/PasswordList.tsx
@@ -47,20 +47,20 @@ const PasswordList: React.FC<PasswordListProps> = ({ passwords }) => {
     );
 
     const TableRow: React.FC<{ password: Password }> = ({ password }) => (
-        <tr key={password.id} className="hover:bg-gray-50">
-            <td className="py-4 px-2 border-b border-gray-300">{password.site_name}</td>
-            <td className="py-4 px-2 border-b border-gray-300">{renderLink(password.site_url)}</td>
-            <td className="py-4 px-2 border-b border-gray-300">{password.login_id ?? "N/A"}</td>
+        <tr key={password.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+            <td className="py-4 px-2 border-b border-gray-300 dark:border-gray-600">{password.site_name}</td>
+            <td className="py-4 px-2 border-b border-gray-300 dark:border-gray-600">{renderLink(password.site_url)}</td>
+            <td className="py-4 px-2 border-b border-gray-300 dark:border-gray-600">{password.login_id ?? "N/A"}</td>
             <td
-                className="py-4 px-2 border-b border-gray-300 cursor-pointer text-center"
+                className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 cursor-pointer text-center"
                 onClick={() => handlePasswordClick(password.password, password.id)}
                 aria-label={`Click to copy password for ${password.site_name}`}
                 title="クリックでコピー"
             >
                 **********
             </td>
-            <td className="py-4 px-2 border-b border-gray-300">{password.email ?? "N/A"}</td>
-            <td className="py-4 px-2 border-b border-gray-300 text-center">
+            <td className="py-4 px-2 border-b border-gray-300 dark:border-gray-600">{password.email ?? "N/A"}</td>
+            <td className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 text-center">
                 <button
                     onClick={() => handleUpdate(password.id)}
                     className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none"
@@ -73,15 +73,15 @@ const PasswordList: React.FC<PasswordListProps> = ({ passwords }) => {
     );
 
     return (
-        <table className="w-full bg-white border border-gray-300">
+        <table className="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700">
             <thead>
-                <tr className="bg-gray-100">
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6 text-left">サイト名</th>
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6 text-left">サイトURL</th>
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6 text-left">ログインID</th>
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6 text-left">パスワード</th>
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6 text-left">メールアドレス</th>
-                    <th className="py-4 px-2 border-b border-gray-300 w-1/6">操作</th>
+                <tr className="bg-gray-100 dark:bg-gray-700">
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6 text-left">サイト名</th>
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6 text-left">サイトURL</th>
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6 text-left">ログインID</th>
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6 text-left">パスワード</th>
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6 text-left">メールアドレス</th>
+                    <th className="py-4 px-2 border-b border-gray-300 dark:border-gray-600 w-1/6">操作</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/app/components/ScheduleCalendar.tsx
+++ b/src/app/components/ScheduleCalendar.tsx
@@ -97,7 +97,12 @@ const ScheduleCalendar = () => {
         height="auto"
       />
       <div className="flex justify-end py-2">
-        <button onClick={handleSync} className="text-sm bg-gray-300 px-2 py-1 rounded">同期</button>
+        <button
+          onClick={handleSync}
+          className="text-sm bg-gray-300 dark:bg-gray-600 dark:text-white px-2 py-1 rounded"
+        >
+          同期
+        </button>
       </div>
       {isOpen && (
         <div
@@ -105,7 +110,7 @@ const ScheduleCalendar = () => {
           onClick={() => setIsOpen(false)}
         >
           <div
-            className="bg-white rounded p-4 w-full max-w-md"
+            className="bg-white dark:bg-gray-800 rounded p-4 w-full max-w-md"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="text-lg font-bold mb-4">{editId ? '予定編集' : '予定登録'}</h2>


### PR DESCRIPTION
## Summary
- tweak background colors for dark mode
- support dark table layout in password list
- update schedule modal styling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0c51b18483329b4adeccefb30fae