### PR TITLE
Enable markdown in author bios

### DIFF
--- a/src/app/authors/page.tsx
+++ b/src/app/authors/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { Author } from '@/types/author';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
 
 const AuthorListPage = () => {
   const [authors, setAuthors] = useState<Author[] | null>(null);
@@ -44,7 +45,9 @@ const AuthorListPage = () => {
         {authors.map((a) => (
           <li key={a.id} className="border p-2 rounded space-y-1">
             <p className="font-semibold">{a.name}</p>
-            {a.bio && <p className="text-sm">{a.bio}</p>}
+            {a.bio && (
+              <MarkdownRenderer className="text-sm">{a.bio}</MarkdownRenderer>
+            )}
             <div className="flex justify-end space-x-2">
               <Link href={`/authors/edit/${a.id}`} className="bg-green-500 text-white px-4 py-2 rounded">
                 編集

--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -2,9 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Image from 'next/image';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeHighlight from 'rehype-highlight';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
 import type { Blog } from '@/types/blog';
 
 const BlogDetailPage = () => {
@@ -42,14 +40,9 @@ const BlogDetailPage = () => {
       />
       <p className="text-sm text-blue-600 underline">{blog.permalink}</p>
 
-      <div className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeHighlight]}
-        >
-          {blog.content_markdown}
-        </ReactMarkdown>
-      </div>
+      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+        {blog.content_markdown}
+      </MarkdownRenderer>
 
       <div className="flex justify-end">
         <button

--- a/src/app/components/MarkdownRenderer.tsx
+++ b/src/app/components/MarkdownRenderer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+
+export type MarkdownRendererProps = {
+  children: string;
+  className?: string;
+};
+
+const allowedElements = [
+  'p',
+  'strong',
+  'em',
+  'blockquote',
+  'code',
+  'pre',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'br',
+];
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ children, className }) => (
+  <ReactMarkdown
+    className={className}
+    remarkPlugins={[remarkGfm]}
+    rehypePlugins={[rehypeHighlight]}
+    allowedElements={allowedElements}
+  >
+    {children}
+  </ReactMarkdown>
+);
+
+export default MarkdownRenderer;

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeHighlight from 'rehype-highlight';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
 import type { Diary } from '@/types/diary';
 
 const DiaryDetailPage = () => {
@@ -32,11 +30,9 @@ const DiaryDetailPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{diary.title}</h1>
-      <div className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-          {diary.content}
-        </ReactMarkdown>
-      </div>
+      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+        {diary.content}
+      </MarkdownRenderer>
       <div className="flex justify-end">
         <button onClick={() => router.push(`/diaries/edit/${diary.id}`)} className="bg-blue-500 text-white px-4 py-2 rounded">
           編集

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeHighlight from 'rehype-highlight';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
 import type { Diary } from '@/types/diary';
 
 const DiaryListPage = () => {
@@ -41,11 +39,9 @@ const DiaryListPage = () => {
             <Link href={`/diaries/${diary.id}`} className="font-semibold hover:underline block">
               {diary.title}
             </Link>
-            <div className="markdown-body line-clamp-3 text-sm">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-                {diary.content}
-              </ReactMarkdown>
-            </div>
+            <MarkdownRenderer className="markdown-body line-clamp-3 text-sm">
+              {diary.content}
+            </MarkdownRenderer>
           </li>
         ))}
       </ul>

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeHighlight from 'rehype-highlight';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
 import type { Wiki } from '@/types/wiki';
 
 const WikiDetailPage = () => {
@@ -32,14 +30,9 @@ const WikiDetailPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{wiki.title}</h1>
-      <div className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeHighlight]}
-        >
-          {wiki.content}
-        </ReactMarkdown>
-      </div>
+      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+        {wiki.content}
+      </MarkdownRenderer>
       <div className="flex justify-end">
         <button
           onClick={() => router.push(`/wikis/edit/${wiki.id}`)}


### PR DESCRIPTION
## Summary
- add reusable `MarkdownRenderer` component to render markdown safely
- use the new renderer for wiki, diary, blog, and author pages
- show author bios with Markdown rendering

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find types)*

------
https://chatgpt.com/codex/tasks/task_e_686d19a13d74833289ff2bdddecd9175