### PR TITLE
Enable raw HTML in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/src/app/components/MarkdownRenderer.tsx
+++ b/src/app/components/MarkdownRenderer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactMarkdown, { type Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
+import rehypeRaw from 'rehype-raw';
 
 export interface MarkdownRendererProps
   extends Omit<Options, 'children'> {
@@ -16,7 +17,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   <div className={`prose max-w-none ${className}`}>
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeHighlight]}
+      rehypePlugins={[rehypeHighlight, rehypeRaw]}
     >
       {children}
     </ReactMarkdown>


### PR DESCRIPTION
## Summary
- allow raw HTML tags in Markdown

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d29ecca04833294ee97dea5eccc6a