### PR TITLE
Improve markdown-body styles

### DIFF
--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -40,7 +40,7 @@ const BlogDetailPage = () => {
       />
       <p className="text-sm text-blue-600 underline">{blog.permalink}</p>
 
-      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+      <MarkdownRenderer className="whitespace-pre-wrap border p-4 rounded bg-white">
         {blog.content_markdown}
       </MarkdownRenderer>
 

--- a/src/app/components/MarkdownRenderer.tsx
+++ b/src/app/components/MarkdownRenderer.tsx
@@ -14,7 +14,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   children,
   className
 }) => (
-  <div className={`prose max-w-none ${className}`}>
+  <div className={`markdown-body max-w-none ${className || ''}`.trim()}>
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeHighlight, rehypeRaw]}

--- a/src/app/diaries/[id]/page.tsx
+++ b/src/app/diaries/[id]/page.tsx
@@ -30,7 +30,7 @@ const DiaryDetailPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{diary.title}</h1>
-      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+      <MarkdownRenderer className="whitespace-pre-wrap border p-4 rounded bg-white">
         {diary.content}
       </MarkdownRenderer>
       <div className="flex justify-end">

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -39,7 +39,7 @@ const DiaryListPage = () => {
             <Link href={`/diaries/${diary.id}`} className="font-semibold hover:underline block">
               {diary.title}
             </Link>
-            <MarkdownRenderer className="markdown-body line-clamp-3 text-sm">
+            <MarkdownRenderer className="line-clamp-3 text-sm">
               {diary.content}
             </MarkdownRenderer>
           </li>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,43 @@ body {
   @apply text-3xl font-bold mb-4 border-b pb-2;
 }
 
+.markdown-body h2 {
+  @apply text-xl font-semibold mt-6 mb-3 pl-3 border-l-4 border-red-600 bg-red-50;
+  font-family: serif;
+}
+
+.markdown-body h3 {
+  @apply text-lg font-semibold mt-5 mb-2 pl-3 border-l-4 border-red-400;
+  font-family: serif;
+}
+
+.markdown-body h4 {
+  @apply text-base font-semibold mt-4 mb-2 pl-3 border-l-4 border-red-300;
+  font-family: serif;
+}
+
+.markdown-body h5,
+.markdown-body h6 {
+  @apply font-semibold mt-4 mb-2 pl-3 border-l-4 border-red-200;
+  font-family: serif;
+}
+
+.markdown-body blockquote {
+  @apply pl-4 border-l-4 border-gray-300 italic text-gray-600 bg-gray-50;
+}
+
+.markdown-body code {
+  @apply bg-gray-100 text-red-600 px-1 rounded;
+}
+
+.markdown-body ul {
+  @apply list-disc pl-6;
+}
+
+.markdown-body ol {
+  @apply list-decimal pl-6;
+}
+
 .markdown-body pre {
   @apply bg-gray-800 text-white p-4 rounded-md overflow-x-auto;
 }

--- a/src/app/wikis/[id]/page.tsx
+++ b/src/app/wikis/[id]/page.tsx
@@ -30,7 +30,7 @@ const WikiDetailPage = () => {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{wiki.title}</h1>
-      <MarkdownRenderer className="markdown-body whitespace-pre-wrap border p-4 rounded bg-white">
+      <MarkdownRenderer className="whitespace-pre-wrap border p-4 rounded bg-white">
         {wiki.content}
       </MarkdownRenderer>
       <div className="flex justify-end">


### PR DESCRIPTION
## Summary
- customize heading styles up to h6
- add styling for blockquotes, code, lists

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3459c2408332ad5576f5e20d47a8