### PR TITLE
Update diary card style and count

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -48,7 +48,7 @@ const MainPage = () => {
       await Promise.all([
         fetchData<Password[]>('/api/passwords', setPasswords, 'passwords'),
         fetchData<Wiki[]>('/api/wiki?limit=5', setWikis, 'wikis'),
-        fetchData<Diary[]>('/api/diary?limit=2', setDiaries, 'diaries'),
+        fetchData<Diary[]>('/api/diary?limit=3', setDiaries, 'diaries'),
         fetchData<Blog[]>('/api/blog?limit=2', setBlogs, 'blogs'),
       ]);
       const now = new Date();

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -18,11 +18,11 @@ const DiaryCards: React.FC<Props> = ({ diaries, onDelete }) => {
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
       {diaries.map((diary) => (
         <div
           key={diary.id}
-          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2"
+          className="border border-gray-200 rounded p-4 bg-blue-50 dark:bg-gray-800 shadow-lg space-y-2"
         >
           <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{diary.content}</p>


### PR DESCRIPTION
## Summary
- display three latest diary cards on main page
- give diary cards a light blue background and stronger shadow for a paper feel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d43aea328833282c4eb5851268d0e