### PR TITLE
Refine card colors

### DIFF
--- a/src/app/components/BlogCards.tsx
+++ b/src/app/components/BlogCards.tsx
@@ -21,7 +21,7 @@ const BlogCards: React.FC<Props> = ({ blogs, onDelete }) => {
       {blogs.map((blog) => (
         <div
           key={blog.id}
-          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2 text-black"
+          className="border rounded p-4 bg-blue-50 dark:bg-gray-800 shadow space-y-2 text-black"
         >
           <h3 className="font-bold mb-2 truncate">{blog.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{blog.content}</p>

--- a/src/app/components/DiaryCards.tsx
+++ b/src/app/components/DiaryCards.tsx
@@ -22,7 +22,7 @@ const DiaryCards: React.FC<Props> = ({ diaries, onDelete }) => {
       {diaries.map((diary) => (
         <div
           key={diary.id}
-          className="border border-gray-200 rounded p-4 bg-blue-200 dark:bg-gray-800 shadow-lg space-y-2 text-black"
+          className="border border-gray-200 rounded p-4 bg-blue-100 dark:bg-gray-800 shadow-lg space-y-2 text-black"
         >
           <h3 className="font-bold mb-2 truncate">{diary.title}</h3>
           <p className="line-clamp-3 text-sm whitespace-pre-wrap">{diary.content}</p>

--- a/src/app/components/PasswordCards.tsx
+++ b/src/app/components/PasswordCards.tsx
@@ -11,7 +11,7 @@ const PasswordCards: React.FC<Props> = ({ passwords }) => {
       {passwords.map((p) => (
         <div
           key={p.id}
-          className="border rounded p-4 bg-white dark:bg-gray-800 shadow space-y-2"
+          className="border rounded p-4 bg-blue-50 dark:bg-gray-800 shadow space-y-2"
         >
           <h3 className="font-bold mb-2 truncate">{p.site_name}</h3>
           <p className="text-sm break-all mb-1">{p.site_url}</p>

--- a/src/app/diaries/page.tsx
+++ b/src/app/diaries/page.tsx
@@ -35,7 +35,7 @@ const DiaryListPage = () => {
       </div>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {diaries.map((diary) => (
-          <li key={diary.id} className="border p-4 rounded space-y-2">
+          <li key={diary.id} className="border p-4 rounded space-y-2 bg-blue-50 dark:bg-gray-800 text-black">
             <Link href={`/diaries/${diary.id}`} className="font-semibold hover:underline block">
               {diary.title}
             </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,8 +80,8 @@ body {
 
 /* Sticky note style for wiki cards */
 .sticky-note {
-  background: #fef3c7;
-  border: 1px solid #fefce8;
+  background: #dbeafe;
+  border: 1px solid #bfdbfe;
   border-radius: 4px;
   padding: 1rem;
   position: relative;
@@ -99,7 +99,7 @@ body {
   transform: translateX(-50%);
   width: 16px;
   height: 16px;
-  background: #f87171;
+  background: #3b82f6;
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## Summary
- switch sticky note style to a soft blue and match accent with header color
- update card components to calmer blue backgrounds
- adjust diary list item colors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734a0e5a9883329ab678df1d897e20