### PR TITLE
Fix missing dependency for fullcalendar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "private-desk",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.11",
         "@fullcalendar/daygrid": "^6.1.11",
         "@fullcalendar/interaction": "^6.1.11",
         "@fullcalendar/react": "^6.1.11",
@@ -792,6 +793,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.11.tgz",
+      "integrity": "sha512-TjG7c8sUz+Vkui2FyCNJ+xqyu0nq653Ibe99A66LoW95oBo6tVhhKIaG1Wh0GVKymYiqAQN/OEdYTuj4ay27kA==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
       }
     },
     "node_modules/@fullcalendar/daygrid": {
@@ -9886,6 +9896,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.11",
     "@fullcalendar/daygrid": "^6.1.11",
     "@fullcalendar/interaction": "^6.1.11",
     "@fullcalendar/react": "^6.1.11",


### PR DESCRIPTION
## Summary
- install `@fullcalendar/core` so FullCalendar components work

## Testing
- `npm test` *(fails: SqliteError: no such table: diary)*

------
https://chatgpt.com/codex/tasks/task_e_687a40bd0d5c8332807fb59be37e80b1