### PR TITLE
Fix ReactQuill findDOMNode error

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -1,6 +1,7 @@
 'use client';
 import dynamic from 'next/dynamic';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import 'react-quill/dist/quill.snow.css';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
@@ -12,6 +13,12 @@ type Props = {
 };
 
 const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
+  if (typeof window !== 'undefined') {
+    // ReactQuill internally expects window.ReactDOM with findDOMNode
+    // which may not be available when using React 18+/Next.js
+    // Attach ReactDOM for compatibility
+    (window as any).ReactDOM = ReactDOM;
+  }
   return <ReactQuill theme="snow" value={value} onChange={onChange} className={className} />;
 };
 


### PR DESCRIPTION
## Summary
- expose `ReactDOM` globally in BlogEditor so ReactQuill can access `findDOMNode`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a43086b788332b21f8d03e58e4fe0