### PR TITLE
Fix ReactQuill init with React 19

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -1,7 +1,12 @@
 'use client';
 import dynamic from 'next/dynamic';
 import React from 'react';
-import ReactDOM from 'react-dom';
+// ReactQuill still relies on the legacy `ReactDOM.findDOMNode` API which was
+// removed from React 19. We provide a minimal polyfill that simply returns the
+// given DOM element. This is sufficient because the ref passed to ReactQuill's
+// editing area already resolves to the underlying element.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findDOMNode = (node: any) => node;
 import 'react-quill/dist/quill.snow.css';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
@@ -14,10 +19,10 @@ type Props = {
 
 const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
   if (typeof window !== 'undefined') {
-    // ReactQuill internally expects window.ReactDOM with findDOMNode
-    // which may not be available when using React 18+/Next.js
-    // Attach ReactDOM for compatibility
-    (window as any).ReactDOM = ReactDOM;
+    // ReactQuill internally expects `window.ReactDOM.findDOMNode`. React 19
+    // removes this API, so we expose a lightweight polyfill that simply
+    // returns the DOM element passed to it.
+    (window as any).ReactDOM = { findDOMNode };
   }
   return <ReactQuill theme="snow" value={value} onChange={onChange} className={className} />;
 };


### PR DESCRIPTION
## Summary
- polyfill `ReactDOM.findDOMNode` for ReactQuill

## Testing
- `npm test` *(fails: SqliteError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_687a44fae1208332808daa7dffa6f0cd