### PR TITLE
Add HTML mode toggle to BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 import dynamic from 'next/dynamic';
-import React from 'react';
+import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import 'react-quill/dist/quill.snow.css';
 
@@ -30,7 +30,30 @@ type Props = {
 };
 
 const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
-  return <ReactQuill theme="snow" value={value} onChange={onChange} className={className} />;
+  const [htmlMode, setHtmlMode] = useState(false);
+
+  return (
+    <div className={className}>
+      <div className="flex justify-end mb-2">
+        <button
+          type="button"
+          onClick={() => setHtmlMode(!htmlMode)}
+          className="text-sm bg-gray-200 px-2 py-1 rounded"
+        >
+          {htmlMode ? 'リッチテキスト' : 'HTML'}モード
+        </button>
+      </div>
+      {htmlMode ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-full border p-2 rounded h-48"
+        />
+      ) : (
+        <ReactQuill theme="snow" value={value} onChange={onChange} />
+      )}
+    </div>
+  );
 };
 
 export default BlogEditor;


### PR DESCRIPTION
## Summary
- add a toggle button inside `BlogEditor` so users can switch to raw HTML editing

## Testing
- `npx tsx scripts/init-db.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a4f13e8c883328fdf0bd5cd1801be