### PR TITLE
Add side-by-side blog editors

### DIFF
--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -112,28 +112,30 @@ const BlogEditPage = () => {
             name="content"
             value={form.content}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded font-mono whitespace-pre"
             rows={4}
             required
           />
         </div>
-        <div>
-          <label className="block">コンテンツ(Markdown)</label>
-          <BlogEditor
-            value={form.content_markdown}
-            onChange={(value) =>
-              setForm({ ...form, content_markdown: value })
-            }
-            className="bg-white"
-          />
-        </div>
-        <div>
-          <label className="block">コンテンツ(HTML)</label>
-          <BlogEditor
-            value={form.content_html}
-            onChange={(value) => setForm({ ...form, content_html: value })}
-            className="bg-white"
-          />
+        <div className="md:flex md:space-x-4">
+          <div className="md:w-1/2">
+            <label className="block">コンテンツ(Markdown)</label>
+            <BlogEditor
+              value={form.content_markdown}
+              onChange={(value) =>
+                setForm({ ...form, content_markdown: value })
+              }
+              className="bg-white"
+            />
+          </div>
+          <div className="md:w-1/2 mt-4 md:mt-0">
+            <label className="block">コンテンツ(HTML)</label>
+            <BlogEditor
+              value={form.content_html}
+              onChange={(value) => setForm({ ...form, content_html: value })}
+              className="bg-white"
+            />
+          </div>
         </div>
         <div>
           <label className="block">アイキャッチ画像</label>

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -77,7 +77,7 @@ const NewBlogPage = () => {
           <textarea
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded font-mono whitespace-pre"
             rows={4}
           />
           <div className="flex justify-end">
@@ -106,28 +106,30 @@ const NewBlogPage = () => {
             name="content"
             value={form.content}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded font-mono whitespace-pre"
             rows={4}
             required
           />
         </div>
-        <div>
-          <label className="block">コンテンツ(Markdown)</label>
-          <BlogEditor
-            value={form.content_markdown}
-            onChange={(value) =>
-              setForm({ ...form, content_markdown: value })
-            }
-            className="bg-white"
-          />
-        </div>
-        <div>
-          <label className="block">コンテンツ(HTML)</label>
-          <BlogEditor
-            value={form.content_html}
-            onChange={(value) => setForm({ ...form, content_html: value })}
-            className="bg-white"
-          />
+        <div className="md:flex md:space-x-4">
+          <div className="md:w-1/2">
+            <label className="block">コンテンツ(Markdown)</label>
+            <BlogEditor
+              value={form.content_markdown}
+              onChange={(value) =>
+                setForm({ ...form, content_markdown: value })
+              }
+              className="bg-white"
+            />
+          </div>
+          <div className="md:w-1/2 mt-4 md:mt-0">
+            <label className="block">コンテンツ(HTML)</label>
+            <BlogEditor
+              value={form.content_html}
+              onChange={(value) => setForm({ ...form, content_html: value })}
+              className="bg-white"
+            />
+          </div>
         </div>
         <div>
           <label className="block">アイキャッチ画像</label>

--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -47,7 +47,7 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
         <textarea
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="w-full border p-2 rounded h-48"
+          className="w-full border p-2 rounded h-48 font-mono whitespace-pre"
         />
       ) : (
         <ReactQuill theme="snow" value={value} onChange={onChange} />


### PR DESCRIPTION
## Summary
- adjust `BlogEditor` to keep whitespace
- allow multi-line fields to use monospace font
- show markdown/html editors side-by-side when creating or editing a blog

## Testing
- `npm install`
- `npx ts-node -O '{"module":"commonjs"}' scripts/init-db.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a54a45468833295f9e21b075483c4