### PR TITLE
Fix BlogEditor async format

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -38,7 +38,7 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
       try {
         const prettier = (await import('prettier/standalone')).default;
         const parserHtml = (await import('prettier/plugins/html')).default;
-        const formatted = prettier.format(value, {
+        const formatted = await prettier.format(value, {
           parser: 'html' as BuiltInParserName,
           plugins: [parserHtml]
         });


### PR DESCRIPTION
## Summary
- fix BlogEditor to await `prettier.format`

## Testing
- `npm run build`
- `npm test` *(fails: SqliteError no such table)*
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_687a5e5db1d48332957d1ba70897c80d