### PR TITLE
Add HTML preview to blog editor pages

### DIFF
--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -117,23 +117,25 @@ const BlogEditPage = () => {
             required
           />
         </div>
-        <div className="md:flex md:space-x-4">
-          <div className="md:w-1/2">
-            <label className="block">コンテンツ(Markdown)</label>
-            <BlogEditor
-              value={form.content_markdown}
-              onChange={(value) =>
-                setForm({ ...form, content_markdown: value })
-              }
-              className="bg-white"
-            />
-          </div>
-          <div className="md:w-1/2 mt-4 md:mt-0">
-            <label className="block">コンテンツ(HTML)</label>
+        <div>
+          <label className="block">コンテンツ(Markdown)</label>
+          <BlogEditor
+            value={form.content_markdown}
+            onChange={(value) => setForm({ ...form, content_markdown: value })}
+            className="bg-white"
+          />
+        </div>
+        <div>
+          <label className="block mb-2">コンテンツ(HTML)</label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <BlogEditor
               value={form.content_html}
               onChange={(value) => setForm({ ...form, content_html: value })}
               className="bg-white"
+            />
+            <div
+              className="border p-2 rounded bg-white min-h-[300px]"
+              dangerouslySetInnerHTML={{ __html: form.content_html }}
             />
           </div>
         </div>

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -111,23 +111,25 @@ const NewBlogPage = () => {
             required
           />
         </div>
-        <div className="md:flex md:space-x-4">
-          <div className="md:w-1/2">
-            <label className="block">コンテンツ(Markdown)</label>
-            <BlogEditor
-              value={form.content_markdown}
-              onChange={(value) =>
-                setForm({ ...form, content_markdown: value })
-              }
-              className="bg-white"
-            />
-          </div>
-          <div className="md:w-1/2 mt-4 md:mt-0">
-            <label className="block">コンテンツ(HTML)</label>
+        <div>
+          <label className="block">コンテンツ(Markdown)</label>
+          <BlogEditor
+            value={form.content_markdown}
+            onChange={(value) => setForm({ ...form, content_markdown: value })}
+            className="bg-white"
+          />
+        </div>
+        <div>
+          <label className="block mb-2">コンテンツ(HTML)</label>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <BlogEditor
               value={form.content_html}
               onChange={(value) => setForm({ ...form, content_html: value })}
               className="bg-white"
+            />
+            <div
+              className="border p-2 rounded bg-white min-h-[300px]"
+              dangerouslySetInnerHTML={{ __html: form.content_html }}
             />
           </div>
         </div>

--- a/src/app/html-playground/page.tsx
+++ b/src/app/html-playground/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import MarkdownRenderer from '@/app/components/MarkdownRenderer';
+
+const initialMarkdown = `# サンプルMarkdown\n\n- これはMarkdown表示例です\n- 上部に表示されます`; 
+
+const initialHtml = `<p>ここにHTMLを書いてください</p>`;
+
+const HtmlPlaygroundPage = () => {
+  const [html, setHtml] = useState(initialHtml);
+
+  return (
+    <div className="space-y-4">
+      <MarkdownRenderer>{initialMarkdown}</MarkdownRenderer>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <textarea
+          value={html}
+          onChange={(e) => setHtml(e.target.value)}
+          className="w-full border p-2 rounded min-h-[300px]"
+        />
+        <div
+          className="w-full border p-2 rounded bg-white"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default HtmlPlaygroundPage;


### PR DESCRIPTION
## Summary
- update blog new/edit pages so Markdown editor is on top and HTML editor with preview is side-by-side
- fix import path in `html-playground` page

## Testing
- `npm run lint`
- `npm test` *(fails: SqliteError: no such table: schedules)*

------
https://chatgpt.com/codex/tasks/task_e_687a6180cc848332b0d0d76462dcc5b8