### PR TITLE
Allow div tag in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -22,7 +22,15 @@ if (typeof window !== 'undefined' && !('findDOMNode' in ReactDOM)) {
   };
 }
 
-const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
+const ReactQuill = dynamic(async () => {
+  const { default: RQ, Quill } = await import('react-quill');
+  const Block = Quill.import('blots/block');
+  class DivBlock extends Block {}
+  DivBlock.blotName = 'div';
+  DivBlock.tagName = 'div';
+  Quill.register(DivBlock, true);
+  return { default: RQ };
+}, { ssr: false });
 
 type Props = {
   value: string;


### PR DESCRIPTION
## Summary
- enable custom Quill format so `<div>` tags are preserved in BlogEditor

## Testing
- `npm test` *(fails: SqliteError no such table: blog)*

------
https://chatgpt.com/codex/tasks/task_e_687b6dedb1f8833284032cf799e39e9e