### PR TITLE
Fix dynamic import for BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -22,15 +22,18 @@ if (typeof window !== 'undefined' && !('findDOMNode' in ReactDOM)) {
   };
 }
 
-const ReactQuill = dynamic(async () => {
-  const { default: RQ, Quill } = await import('react-quill');
-  const Block = Quill.import('blots/block');
-  class DivBlock extends Block {}
-  DivBlock.blotName = 'div';
-  DivBlock.tagName = 'div';
-  Quill.register(DivBlock, true);
-  return { default: RQ };
-}, { ssr: false });
+const ReactQuill = dynamic(
+  () =>
+    import('react-quill').then((mod) => {
+      const Block = mod.Quill.import('blots/block');
+      class DivBlock extends Block {}
+      DivBlock.blotName = 'div';
+      DivBlock.tagName = 'div';
+      mod.Quill.register(DivBlock, true);
+      return mod.default;
+    }),
+  { ssr: false }
+);
 
 type Props = {
   value: string;


### PR DESCRIPTION
## Summary
- avoid passing async function to `next/dynamic`
- return the loaded module from `import('react-quill')`

## Testing
- `npm install`
- `npm test` *(fails: SqliteError - no such table)*

------
https://chatgpt.com/codex/tasks/task_e_687b766d9b188332872de594ef6714f5