### PR TITLE
Fix Quill import usage in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -25,11 +25,15 @@ if (typeof window !== 'undefined' && !('findDOMNode' in ReactDOM)) {
 const ReactQuill = dynamic(
   () =>
     import('react-quill').then((mod) => {
-      const Block = mod.Quill.import('blots/block');
+      const Quill = (mod as any).default?.Quill ?? (mod as any).Quill;
+      if (!Quill) {
+        throw new Error('Quill not found in react-quill module');
+      }
+      const Block = Quill.import('blots/block');
       class DivBlock extends Block {}
       DivBlock.blotName = 'div';
       DivBlock.tagName = 'div';
-      mod.Quill.register(DivBlock, true);
+      Quill.register(DivBlock, true);
       return mod.default;
     }),
   { ssr: false }


### PR DESCRIPTION
## Summary
- fix ReactQuill dynamic import to access the `Quill` static property correctly
- throw explicit error if Quill is not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b7d191fd08332b0f897c14864b384