### PR TITLE
Fix BlogEditor prettier type

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -53,10 +53,10 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
       try {
         const prettier = (await import('prettier/standalone')).default;
         const parserHtml = (await import('prettier/plugins/html')).default;
-        const formatted = await prettier.format(value, {
+        const formatted = (await prettier.format(value, {
           parser: 'html' as BuiltInParserName,
-          plugins: [parserHtml]
-        });
+          plugins: [parserHtml],
+        })) as string;
         onChange(formatted);
       } catch (err) {
         console.error('format error', err);


### PR DESCRIPTION
## Summary
- resolve TypeScript error in BlogEditor when formatting HTML

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7ff4491c8332bea403c84ca14e4f