### PR TITLE
Fix BlogEditor dynamic import typing

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -22,22 +22,18 @@ if (typeof window !== 'undefined' && !('findDOMNode' in ReactDOM)) {
   };
 }
 
-const ReactQuill = dynamic(
-  () =>
-    import('react-quill').then((mod) => {
-      const Quill = (mod as any).default?.Quill ?? (mod as any).Quill;
-      if (!Quill) {
-        throw new Error('Quill not found in react-quill module');
-      }
-      const Block = Quill.import('blots/block');
-      class DivBlock extends Block {}
-      DivBlock.blotName = 'div';
-      DivBlock.tagName = 'div';
-      Quill.register(DivBlock, true);
-      return mod.default;
-    }),
-  { ssr: false }
-);
+const ReactQuill = dynamic(async () => {
+  const { default: QuillComponent, Quill } = await import('react-quill');
+  if (!Quill) {
+    throw new Error('Quill not found in react-quill module');
+  }
+  const Block = Quill.import('blots/block');
+  class DivBlock extends Block {}
+  DivBlock.blotName = 'div';
+  DivBlock.tagName = 'div';
+  Quill.register(DivBlock, true);
+  return QuillComponent;
+}, { ssr: false }) as typeof import('react-quill');
 
 type Props = {
   value: string;
@@ -55,9 +51,9 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
         const parserHtml = (await import('prettier/plugins/html')).default;
         const formatted = await prettier.format(value, {
           parser: 'html' as BuiltInParserName,
-          plugins: [parserHtml]
+          plugins: [parserHtml],
         });
-        onChange(formatted);
+        onChange(String(formatted));
       } catch (err) {
         console.error('format error', err);
       }


### PR DESCRIPTION
## Summary
- refine `BlogEditor` dynamic import typing for ReactQuill
- ensure formatted HTML is passed to `onChange` as a string

## Testing
- `npx next build`
- `npm test` *(fails: SQLite table errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b7ff4491c8332bea403c84ca14e4f