### PR TITLE
Fix syntax error in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -50,7 +50,7 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
       try {
         const prettier = (await import('prettier/standalone')).default;
         const parserHtml = (await import('prettier/plugins/html')).default;
-        const formatted = (await prettier.format(value, {
+        const formatted = await prettier.format(value, {
           parser: 'html' as BuiltInParserName,
           plugins: [parserHtml],
         });


### PR DESCRIPTION
## Summary
- fix parentheses usage when formatting HTML in BlogEditor

## Testing
- `npm run lint`
- `npm test` *(fails: SqliteError - no such table)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b8a51fa488332a0d2ef259134ba51