### PR TITLE
Fix Quill detection in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -1,40 +1,47 @@
-'use client';
-import dynamic from 'next/dynamic';
-import React, { useState } from 'react';
-import type { BuiltInParserName } from 'prettier';
-import ReactDOM from 'react-dom';
-import 'react-quill/dist/quill.snow.css';
+"use client";
+import dynamic from "next/dynamic";
+import React, { useState } from "react";
+import type { BuiltInParserName } from "prettier";
+import ReactDOM from "react-dom";
+import "react-quill/dist/quill.snow.css";
 
 // Polyfill for ReactDOM.findDOMNode which was removed in React 19
 type NodeLike = Element | { current?: Element | null } | null;
 
-if (typeof window !== 'undefined' && !('findDOMNode' in ReactDOM)) {
-  (ReactDOM as unknown as { findDOMNode(node: NodeLike): Element | null }).findDOMNode = (
-    node: NodeLike,
-  ): Element | null => {
-    if (node && 'nodeType' in node && (node as Node).nodeType === Node.ELEMENT_NODE) {
+if (typeof window !== "undefined" && !("findDOMNode" in ReactDOM)) {
+  (
+    ReactDOM as unknown as { findDOMNode(node: NodeLike): Element | null }
+  ).findDOMNode = (node: NodeLike): Element | null => {
+    if (
+      node &&
+      "nodeType" in node &&
+      (node as Node).nodeType === Node.ELEMENT_NODE
+    ) {
       return node as Element;
     }
-    if (node && 'current' in node) {
+    if (node && "current" in node) {
       return node.current ?? null;
     }
     return node as Element | null;
   };
 }
 
-const ReactQuill = dynamic(async () => {
-  const { default: QuillComponent, Quill } = await import('react-quill');
-  if (!Quill) {
-    throw new Error('Quill not found in react-quill module');
-  }
-  const Block = Quill.import('blots/block');
-  class DivBlock extends Block {}
-  DivBlock.blotName = 'div';
-  DivBlock.tagName = 'div';
-  Quill.register(DivBlock, true);
-  return QuillComponent;
-}, { ssr: false }) as typeof import('react-quill');
-
+const ReactQuill = dynamic(
+  async () => {
+    const mod = await import("react-quill");
+    const Quill = (mod as any).Quill ?? (mod.default as any).Quill;
+    if (!Quill) {
+      throw new Error("Quill not found in react-quill module");
+    }
+    const Block = Quill.import("blots/block");
+    class DivBlock extends Block {}
+    DivBlock.blotName = "div";
+    DivBlock.tagName = "div";
+    Quill.register(DivBlock, true);
+    return mod.default;
+  },
+  { ssr: false },
+) as typeof import("react-quill");
 
 type Props = {
   value: string;
@@ -48,15 +55,15 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
   const toggleMode = async () => {
     if (!htmlMode) {
       try {
-        const prettier = (await import('prettier/standalone')).default;
-        const parserHtml = (await import('prettier/plugins/html')).default;
+        const prettier = (await import("prettier/standalone")).default;
+        const parserHtml = (await import("prettier/plugins/html")).default;
         const formatted = await prettier.format(value, {
-          parser: 'html' as BuiltInParserName,
+          parser: "html" as BuiltInParserName,
           plugins: [parserHtml],
         });
         onChange(String(formatted));
       } catch (err) {
-        console.error('format error', err);
+        console.error("format error", err);
       }
     }
     setHtmlMode(!htmlMode);
@@ -70,7 +77,7 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
           onClick={toggleMode}
           className="text-sm bg-gray-200 px-2 py-1 rounded"
         >
-          {htmlMode ? 'リッチテキスト' : 'HTML'}モード
+          {htmlMode ? "リッチテキスト" : "HTML"}モード
         </button>
       </div>
       {htmlMode ? (


### PR DESCRIPTION
## Summary
- handle both named and default Quill exports when loading `react-quill`

## Testing
- `npm test` *(fails: SqliteError: no such table: blog)*

------
https://chatgpt.com/codex/tasks/task_e_687bb1712b808332b1efb25edb6a2854