### PR TITLE
Remove `any` usage in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -29,7 +29,12 @@ if (typeof window !== "undefined" && !("findDOMNode" in ReactDOM)) {
 const ReactQuill = dynamic(
   async () => {
     const mod = await import("react-quill");
-    const Quill = (mod as any).Quill ?? (mod.default as any).Quill;
+    type QuillType = typeof import("quill")["default"];
+    const typedMod = mod as unknown as {
+      default: { Quill: QuillType };
+      Quill: QuillType;
+    };
+    const Quill = typedMod.Quill ?? typedMod.default.Quill;
     if (!Quill) {
       throw new Error("Quill not found in react-quill module");
     }


### PR DESCRIPTION
## Summary
- fix ESLint errors in `BlogEditor` by replacing `any` cast with a typed module cast

## Testing
- `npm run build`
- `npm test` *(fails: SqliteError: no such table)*

------
https://chatgpt.com/codex/tasks/task_e_687bb50a0bac83328247121091fbdf6c