### PR TITLE
Document BlogEditor HTML mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,18 @@ GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END P
 GOOGLE_CALENDAR_ID=your-calendar-id@group.calendar.google.com
 ```
 
+
+## ブログエディタのHTMLモード例
+
+`BlogEditor` では右上のボタンでリッチテキストとHTMLを切り替えられます。HTMLモードにした状態で、以下のように`<ol>`を`<div>`で包んだHTMLを直接入力すると、そのまま`content_html`に保存されます。
+
+```html
+<div class="table-of-contents">
+  <ol>
+    <li>項目1</li>
+    <li>項目2</li>
+  </ol>
+</div>
+```
+
+リッチテキストモードへ戻すとQuillが`<div>`を削除してしまうため、このようなネスト構造を保持したい場合はHTMLモードで編集したまま保存してください。

--- a/tests/api/blogHtml.test.ts
+++ b/tests/api/blogHtml.test.ts
@@ -1,0 +1,37 @@
+import { POST } from '../../src/app/api/blog/route';
+import { runSelect, runExecute } from '../../src/lib/db';
+
+function createPostRequest(body: any) {
+  return new Request('http://localhost/api/blog', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/blog with custom HTML', () => {
+  const html = '<div class="table-of-contents"><ol><li>1</li><li>2</li></ol></div>';
+  const entry = {
+    title: 'jest html blog',
+    content: 'c',
+    content_markdown: '<p>c</p>',
+    content_html: html,
+    eyecatch: 'img.png',
+    permalink: 'jest-html-blog',
+    site: 'example.com',
+    author: 'jest',
+    persona: 'tester',
+  };
+
+  afterAll(() => {
+    runExecute('DELETE FROM blog WHERE title = ?', [entry.title]);
+  });
+
+  it('should store HTML as provided', async () => {
+    const req = createPostRequest(entry);
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    const row = runSelect('SELECT content_html FROM blog WHERE title = ?', [entry.title])[0];
+    expect(row.content_html).toBe(html);
+  });
+});


### PR DESCRIPTION
## Summary
- document how to keep nested `<div>` and `<ol>` using BlogEditor HTML mode
- add a regression test that verifies HTML is stored as-is

## Testing
- `npm install`
- `npx ts-node scripts/init-db.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bb98bbda48332b194a6ddeaa1a9d5