### PR TITLE
Fix TypeScript build error in BlogEditor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -27,7 +27,7 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
 
   useEffect(() => {
     if (editor && !htmlMode && editor.getHTML() !== value) {
-      editor.commands.setContent(value, false);
+      editor.commands.setContent(value, { emitUpdate: false });
     }
   }, [value, htmlMode, editor]);
 


### PR DESCRIPTION
## Summary
- use options object for `setContent` to match Tiptap API

## Testing
- `npm run build`
- `npm test` *(fails: no such table errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c1ff1dfb08332ac1c0e442cf44363