### PR TITLE
Add HTML/Markdown conversion for blog pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,15 @@
         "better-sqlite3": "^11.10.0",
         "date-fns": "^3.6.0",
         "googleapis": "^131.0.0",
+        "marked": "^16.1.1",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "turndown": "^7.2.0"
       },
       "devDependencies": {
         "@axe-core/react": "^4.10.2",
@@ -2232,6 +2234,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -10010,6 +10018,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
+      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -13683,6 +13703,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "better-sqlite3": "^11.10.0",
     "date-fns": "^3.6.0",
     "googleapis": "^131.0.0",
+    "marked": "^16.1.1",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "turndown": "^7.2.0"
   },
   "devDependencies": {
     "@axe-core/react": "^4.10.2",

--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -4,6 +4,8 @@ import { useRouter, useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import type { Blog } from '@/types/blog';
 import BlogEditor from '@/app/components/BlogEditor';
+import { marked } from 'marked';
+import TurndownService from 'turndown';
 
 const BlogEditPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -90,6 +92,18 @@ const BlogEditPage = () => {
     }
   };
 
+  const markdownToHtml = () => {
+    setForm({ ...form, content_html: marked(form.content_markdown) });
+  };
+
+  const htmlToMarkdown = () => {
+    const turndownService = new TurndownService();
+    setForm({
+      ...form,
+      content_markdown: turndownService.turndown(form.content_html),
+    });
+  };
+
   if (loading) return <div>読み込み中...</div>;
 
   return (
@@ -124,6 +138,22 @@ const BlogEditPage = () => {
             onChange={(value) => setForm({ ...form, content_markdown: value })}
             className="bg-white"
           />
+          <div className="flex justify-end gap-2 mt-2">
+            <button
+              type="button"
+              onClick={markdownToHtml}
+              className="btn btn-secondary btn-sm"
+            >
+              Markdown→HTML
+            </button>
+            <button
+              type="button"
+              onClick={htmlToMarkdown}
+              className="btn btn-secondary btn-sm"
+            >
+              HTML→Markdown
+            </button>
+          </div>
         </div>
         <div>
           <label className="block mb-2 text-white">コンテンツ(HTML)</label>

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import BlogEditor from '@/app/components/BlogEditor';
+import { marked } from 'marked';
+import TurndownService from 'turndown';
 
 const NewBlogPage = () => {
   const router = useRouter();
@@ -68,6 +70,18 @@ const NewBlogPage = () => {
     }
   };
 
+  const markdownToHtml = () => {
+    setForm({ ...form, content_html: marked(form.content_markdown) });
+  };
+
+  const htmlToMarkdown = () => {
+    const turndownService = new TurndownService();
+    setForm({
+      ...form,
+      content_markdown: turndownService.turndown(form.content_html),
+    });
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold text-white">ブログ登録</h1>
@@ -118,6 +132,22 @@ const NewBlogPage = () => {
             onChange={(value) => setForm({ ...form, content_markdown: value })}
             className="bg-white"
           />
+          <div className="flex justify-end gap-2 mt-2">
+            <button
+              type="button"
+              onClick={markdownToHtml}
+              className="btn btn-secondary btn-sm"
+            >
+              Markdown→HTML
+            </button>
+            <button
+              type="button"
+              onClick={htmlToMarkdown}
+              className="btn btn-secondary btn-sm"
+            >
+              HTML→Markdown
+            </button>
+          </div>
         </div>
         <div>
           <label className="block mb-2 text-white">コンテンツ(HTML)</label>


### PR DESCRIPTION
## Summary
- add `marked` and `turndown` packages
- allow converting between HTML and Markdown in blog new/edit pages

## Testing
- `npm run test:all` *(fails: Design Accessibility Tests and MainPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687eddef90e0833296cd83a77f0e2c20