### PR TITLE
Fix marked typing conflict

### DIFF
--- a/src/app/blogs/edit/[id]/page.tsx
+++ b/src/app/blogs/edit/[id]/page.tsx
@@ -93,7 +93,10 @@ const BlogEditPage = () => {
   };
 
   const markdownToHtml = () => {
-    setForm({ ...form, content_html: marked(form.content_markdown) });
+    setForm({
+      ...form,
+      content_html: marked(form.content_markdown, { async: false }),
+    });
   };
 
   const htmlToMarkdown = () => {

--- a/src/app/blogs/new/page.tsx
+++ b/src/app/blogs/new/page.tsx
@@ -71,7 +71,10 @@ const NewBlogPage = () => {
   };
 
   const markdownToHtml = () => {
-    setForm({ ...form, content_html: marked(form.content_markdown) });
+    setForm({
+      ...form,
+      content_html: marked(form.content_markdown, { async: false }),
+    });
   };
 
   const htmlToMarkdown = () => {


### PR DESCRIPTION
## Summary
- ensure `marked` is invoked synchronously when converting markdown

## Testing
- `npm run build`
- `npm test` *(fails: 4 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ee498bdc08332aca59714b1afa20a