### PR TITLE
Fix paragraph spacing in HTML editor

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -40,7 +40,9 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
           parser: "html" as BuiltInParserName,
           plugins: [parserHtml],
         });
-        onChange(String(formatted));
+        const cleaned = String(formatted)
+          .replace(/<p>\s*\n\s*(.*?)\s*\n\s*<\/p>/gs, (_, p) => `<p>${p.trim()}</p>`);
+        onChange(cleaned);
       } catch (err) {
         console.error("format error", err);
       }


### PR DESCRIPTION
## Summary
- adjust BlogEditor formatting to remove extra newlines in `<p>` tags

## Testing
- `npm test` *(fails: 4 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f57a24d2c8332824ff7db13301cd1