### PR TITLE
Fix BlogEditor regex and update ts target

### DIFF
--- a/src/app/components/BlogEditor.tsx
+++ b/src/app/components/BlogEditor.tsx
@@ -40,8 +40,10 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
           parser: "html" as BuiltInParserName,
           plugins: [parserHtml],
         });
-        const cleaned = String(formatted)
-          .replace(/<p>\s*\n\s*(.*?)\s*\n\s*<\/p>/gs, (_, p) => `<p>${p.trim()}</p>`);
+        const cleaned = String(formatted).replace(
+          /<p>\s*([\s\S]*?)\s*<\/p>/g,
+          (_, p) => `<p>${p.trim()}</p>`,
+        );
         onChange(cleaned);
       } catch (err) {
         console.error("format error", err);
@@ -68,7 +70,10 @@ const BlogEditor: React.FC<Props> = ({ value, onChange, className }) => {
           className="w-full border p-2 rounded h-48 font-mono whitespace-pre"
         />
       ) : (
-        <EditorContent editor={editor} className="border p-2 rounded min-h-[3rem]" />
+        <EditorContent
+          editor={editor}
+          className="border p-2 rounded min-h-[3rem]"
+        />
       )}
     </div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2018",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- target ES2018 in TypeScript config
- improve BlogEditor paragraph cleaning regex

## Testing
- `npx prettier src/app/components/BlogEditor.tsx tsconfig.json --write`
- `npm run lint`
- `npm test` *(fails: 2 suites, 4 tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f78629a54833286d9191794f055a9