### PR TITLE
Add personal spending tracking

### DIFF
--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -62,6 +62,7 @@ db.exec(`
     category TEXT NOT NULL,
     amount INTEGER NOT NULL,
     shop TEXT NOT NULL,
+    used_by TEXT,
     product_name TEXT,
     remark TEXT,
     used_at TEXT NOT NULL,

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -56,9 +56,9 @@ const MainPage = () => {
       const res = await fetch(`/api/expense?month=${month}`);
       if (res.ok) {
         const data: Expense[] = await res.json();
-        const mTotal = data.reduce((sum, e) => sum + e.amount, 0);
+        const mTotal = data.filter(e => e.used_by === '共有').reduce((sum, e) => sum + e.amount, 0);
         const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-        const tTotal = data.filter(e => e.used_at === todayStr).reduce((s, e) => s + e.amount, 0);
+        const tTotal = data.filter(e => e.used_at === todayStr && e.used_by === '共有').reduce((s, e) => s + e.amount, 0);
         setMonthTotal(mTotal);
         setTodayTotal(tTotal);
       }
@@ -73,7 +73,7 @@ const MainPage = () => {
 
   return (
     <div className="space-y-4">
-      <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 float p-6 mb-6">
+      <div className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 float p-6 mb-6">
         <div className="flex items-center justify-between">
           <div className="space-y-1">
             <p className="text-lg font-semibold text-gray-700">本日の支出</p>
@@ -113,7 +113,7 @@ const MainPage = () => {
         {/* 左側：Wiki / 日報 / ブログ */}
         <div className="lg:col-span-2 space-y-6">
 
-          <section className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
+          <section className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
             <h2 className="heading-2 mb-4 flex items-center">
               📔 最新日報
             </h2>
@@ -133,7 +133,7 @@ const MainPage = () => {
               </Link>
             </div>
           </section>
-          <section className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
+          <section className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
             <h2 className="heading-2 mb-4 flex items-center">
               📝 最新Wiki
             </h2>
@@ -151,7 +151,7 @@ const MainPage = () => {
             </div>
           </section>
           
-          <section className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
+          <section className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
             <h2 className="heading-2 mb-4 flex items-center">
               ✍️ 最新ブログ
             </h2>
@@ -174,7 +174,7 @@ const MainPage = () => {
         </div>
 
         {/* 右側：カレンダー */}
-        <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
+        <div className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
           <h2 className="heading-2 mb-4 flex items-center">
             📅 予定カレンダー
           </h2>
@@ -183,7 +183,7 @@ const MainPage = () => {
 
         {/* 下段：全幅パスワード一覧 */}
         <div className="lg:col-span-3">
-          <section className="bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
+          <section className="card bg-white/90 backdrop-blur-sm rounded-xl border border-white/40 shadow-lg transition-all duration-300 p-6">
             <h2 className="heading-2 mb-4 flex items-center">
               🔐 パスワード一覧
             </h2>

--- a/src/app/api/expense/[id]/route.ts
+++ b/src/app/api/expense/[id]/route.ts
@@ -23,13 +23,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   const { id } = await params;
   try {
     const body = await request.json();
-    const { category, amount, shop, used_at, product_name, remark } = body;
+    const { category, amount, shop, used_at, used_by, product_name, remark } = body;
     if (!category || !amount || !shop || !used_at) {
       return NextResponse.json({ error: 'required fields missing' }, { status: 400 });
     }
     runExecute(
-      'UPDATE expenses SET category = ?, amount = ?, shop = ?, used_at = ?, product_name = ?, remark = ? WHERE id = ?',
-      [category, Number(amount), shop, used_at, product_name ?? null, remark ?? null, Number(id)]
+      'UPDATE expenses SET category = ?, amount = ?, shop = ?, used_at = ?, used_by = ?, product_name = ?, remark = ? WHERE id = ?',
+      [category, Number(amount), shop, used_at, used_by ?? null, product_name ?? null, remark ?? null, Number(id)]
     );
     return NextResponse.json({ message: 'expense updated successfully.' });
   } catch (error) {

--- a/src/app/api/expense/route.ts
+++ b/src/app/api/expense/route.ts
@@ -26,13 +26,13 @@ export async function GET(request: Request) {
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { category, amount, shop, used_at, product_name, remark } = body;
+    const { category, amount, shop, used_at, used_by, product_name, remark } = body;
     if (!category || !amount || !shop || !used_at) {
       return NextResponse.json({ error: '必須項目不足' }, { status: 400 });
     }
     runExecute(
-      'INSERT INTO expenses (category, amount, shop, used_at, product_name, remark) VALUES (?, ?, ?, ?, ?, ?)',
-      [category, Number(amount), shop, used_at, product_name ?? null, remark ?? null]
+      'INSERT INTO expenses (category, amount, shop, used_at, used_by, product_name, remark) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [category, Number(amount), shop, used_at, used_by ?? null, product_name ?? null, remark ?? null]
     );
     return NextResponse.json({ message: '登録成功' });
   } catch (error) {

--- a/src/app/expenses/edit/[id]/page.tsx
+++ b/src/app/expenses/edit/[id]/page.tsx
@@ -10,10 +10,11 @@ const ExpenseEditPage = () => {
     category: string;
     amount: string;
     shop: string;
+    used_by: string | null;
     product_name: string | null;
     remark: string | null;
     used_at: string;
-  }>({ category: '', amount: '', shop: '', product_name: '', remark: '', used_at: '' });
+  }>({ category: '', amount: '', shop: '', used_by: '', product_name: '', remark: '', used_at: '' });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -25,6 +26,7 @@ const ExpenseEditPage = () => {
           category: data.category,
           amount: String(data.amount),
           shop: data.shop,
+          used_by: data.used_by ?? '',
           product_name: data.product_name ?? '',
           remark: data.remark ?? '',
           used_at: data.used_at,
@@ -44,6 +46,7 @@ const ExpenseEditPage = () => {
         category: form.category,
         amount: Number(form.amount),
         shop: form.shop,
+        used_by: form.used_by,
         product_name: form.product_name,
         remark: form.remark,
         used_at: form.used_at,
@@ -86,6 +89,14 @@ const ExpenseEditPage = () => {
         <div className="space-y-4 mb-6">
           <label className="block text-gray-800 font-semibold mb-2">お店</label>
           <input value={form.shop} onChange={(e) => setForm({ ...form, shop: e.target.value })} className="w-full border border-gray-300 p-3 rounded-lg bg-white text-gray-900 placeholder-gray-500 transition-all duration-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent hover:border-gray-400" required />
+        </div>
+        <div className="space-y-4 mb-6">
+          <label className="block text-gray-800 font-semibold mb-2">利用者</label>
+          <input
+            value={form.used_by ?? ''}
+            onChange={(e) => setForm({ ...form, used_by: e.target.value })}
+            className="w-full border border-gray-300 p-3 rounded-lg bg-white text-gray-900 placeholder-gray-500 transition-all duration-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent hover:border-gray-400"
+          />
         </div>
         <div className="space-y-4 mb-6">
           <label className="block text-gray-800 font-semibold mb-2">商品名</label>

--- a/src/app/expenses/new/page.tsx
+++ b/src/app/expenses/new/page.tsx
@@ -7,6 +7,7 @@ const NewExpensePage = () => {
   const [category, setCategory] = useState('');
   const [amount, setAmount] = useState('');
   const [shop, setShop] = useState('');
+  const [usedBy, setUsedBy] = useState('');
   const [productName, setProductName] = useState('');
   const [remark, setRemark] = useState('');
   const [usedAt, setUsedAt] = useState('');
@@ -21,6 +22,7 @@ const NewExpensePage = () => {
         amount: Number(amount),
         shop,
         used_at: usedAt,
+        used_by: usedBy || null,
         product_name: productName || null,
         remark: remark || null,
       }),
@@ -50,6 +52,10 @@ const NewExpensePage = () => {
         <div className="space-y-4 mb-6">
           <label className="block text-gray-800 font-semibold mb-2">お店</label>
           <input value={shop} onChange={(e) => setShop(e.target.value)} className="w-full border border-gray-300 p-3 rounded-lg bg-white text-gray-900 placeholder-gray-500 transition-all duration-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent hover:border-gray-400" required />
+        </div>
+        <div className="space-y-4 mb-6">
+          <label className="block text-gray-800 font-semibold mb-2">利用者</label>
+          <input value={usedBy} onChange={(e) => setUsedBy(e.target.value)} className="w-full border border-gray-300 p-3 rounded-lg bg-white text-gray-900 placeholder-gray-500 transition-all duration-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent hover:border-gray-400" />
         </div>
         <div className="space-y-4 mb-6">
           <label className="block text-gray-800 font-semibold mb-2">商品名</label>

--- a/src/app/expenses/page.tsx
+++ b/src/app/expenses/page.tsx
@@ -46,6 +46,7 @@ const ExpenseListPage = () => {
             <th className="px-2 py-1 border">勘定科目</th>
             <th className="px-2 py-1 border">金額</th>
             <th className="px-2 py-1 border">お店</th>
+            <th className="px-2 py-1 border">利用者</th>
             <th className="px-2 py-1 border">商品名</th>
             <th className="px-2 py-1 border">備考</th>
             <th className="px-2 py-1 border">操作</th>
@@ -58,6 +59,7 @@ const ExpenseListPage = () => {
               <td className="px-2 py-1 border">{e.category}</td>
               <td className="px-2 py-1 border text-right">¥{e.amount}</td>
               <td className="px-2 py-1 border">{e.shop}</td>
+              <td className="px-2 py-1 border">{e.used_by}</td>
               <td className="px-2 py-1 border">{e.product_name}</td>
               <td className="px-2 py-1 border whitespace-pre-wrap">{e.remark}</td>
               <td className="px-2 py-1 border text-center space-x-2">

--- a/src/types/expense.d.ts
+++ b/src/types/expense.d.ts
@@ -3,6 +3,7 @@ export type Expense = {
   category: string;
   amount: number;
   shop: string;
+  used_by?: string | null;
   product_name?: string | null;
   remark?: string | null;
   used_at: string;

--- a/tests/api/expense.test.ts
+++ b/tests/api/expense.test.ts
@@ -31,7 +31,7 @@ describe('GET /api/expense', () => {
 });
 
 describe('POST /api/expense', () => {
-  const entry = { category: 'jest', amount: 123, shop: 'store', used_at: '2099-01-01', product_name: 'item', remark: 'memo' };
+  const entry = { category: 'jest', amount: 123, shop: 'store', used_at: '2099-01-01', used_by: '共有', product_name: 'item', remark: 'memo' };
   afterAll(() => {
     runExecute('DELETE FROM expenses WHERE category = ?', [entry.category]);
   });
@@ -45,6 +45,7 @@ describe('POST /api/expense', () => {
 
     const rows = runSelect('SELECT * FROM expenses WHERE category = ?', [entry.category]);
     expect(rows.length).toBe(1);
+    expect(rows[0].used_by).toBe('共有');
   });
 
   it('should return 400 when required fields missing', async () => {
@@ -55,7 +56,7 @@ describe('POST /api/expense', () => {
 });
 
 describe('Expense update and delete', () => {
-  const entry = { category: 'jest2', amount: 100, shop: 'shop', used_at: '2099-01-02', product_name: 'item2', remark: 'memo2' };
+  const entry = { category: 'jest2', amount: 100, shop: 'shop', used_at: '2099-01-02', used_by: '夫', product_name: 'item2', remark: 'memo2' };
   let id: number;
   afterAll(() => {
     runExecute('DELETE FROM expenses WHERE id = ?', [id]);
@@ -68,7 +69,7 @@ describe('Expense update and delete', () => {
     const row = runSelect('SELECT * FROM expenses WHERE category = ?', [entry.category])[0];
     id = row.id;
 
-    const updateReq = createPutRequest(id, { ...entry, category: 'up', product_name: 'updated', remark: 'updated memo' });
+    const updateReq = createPutRequest(id, { ...entry, category: 'up', used_by: '妻', product_name: 'updated', remark: 'updated memo' });
     const updateRes = await PUT(updateReq as any, { params: Promise.resolve({ id: String(id) }) } as any);
     expect(updateRes.status).toBe(200);
 
@@ -76,6 +77,7 @@ describe('Expense update and delete', () => {
     expect(updatedRow.category).toBe('up');
     expect(updatedRow.product_name).toBe('updated');
     expect(updatedRow.remark).toBe('updated memo');
+    expect(updatedRow.used_by).toBe('妻');
 
     const deleteReq = new Request(`http://localhost/api/expense/${id}`, { method: 'DELETE' });
     const deleteRes = await DELETE(deleteReq as any, { params: Promise.resolve({ id: String(id) }) } as any);

--- a/tests/components/MainPage.test.tsx
+++ b/tests/components/MainPage.test.tsx
@@ -67,7 +67,10 @@ describe('MainPage', () => {
     wikis: [{ id: 1, title: 'Test Wiki', content: 'Wiki content' }],
     diaries: [{ id: 1, title: 'Test Diary', content: 'Diary content', created_at: '2025-01-01' }],
     blogs: [{ id: 1, title: 'Test Blog', content: 'Blog content', created_at: '2025-01-01' }],
-    expenses: [{ id: 1, amount: 1000, used_at: '2025-01-21' }, { id: 2, amount: 2000, used_at: '2025-01-20' }]
+    expenses: [
+      { id: 1, amount: 1000, used_at: '2025-01-21', used_by: '共有' },
+      { id: 2, amount: 2000, used_at: '2025-01-20', used_by: '妻' }
+    ]
   };
 
   beforeEach(() => {
@@ -132,9 +135,9 @@ describe('MainPage', () => {
     const expenseCard = screen.getByText('本日の支出').closest('div');
     expect(expenseCard).toHaveClass('card', 'float', 'p-6', 'mb-6');
     
-    // Should show today's expenses (¥1,000) and month total (¥3,000)
+    // Should show today's shared expenses (¥1,000) and month total (¥1,000)
     expect(screen.getByText('¥1,000')).toBeInTheDocument();
-    expect(screen.getByText('¥3,000')).toBeInTheDocument();
+    expect(screen.getAllByText('¥1,000').length).toBeGreaterThan(1);
   });
 
   it('renders action buttons with proper styling and icons', async () => {


### PR DESCRIPTION
## Summary
- allow expenses to store the user who spent it
- filter totals on main page to show only shared expenses
- adjust pages and tests for new field

## Testing
- `npm test` *(fails: Layout.test.tsx, MainPage.test.tsx, design-accessibility.test.tsx)*
- `npx ts-node scripts/init-db.ts`
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_68801fad10888332b0081b2ea7c435f0