### PR TITLE
feat: filter expenses by category

### DIFF
--- a/src/app/api/expense/route.ts
+++ b/src/app/api/expense/route.ts
@@ -5,17 +5,26 @@ import type { Expense } from '@/types/expense';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const month = searchParams.get('month');
+  const category = searchParams.get('category');
   try {
+    let query = 'SELECT * FROM expenses';
+    const params: (string | number | null)[] = [];
+    const conditions: string[] = [];
     if (month) {
       const start = `${month}-01`;
       const end = `${month}-31`;
-      const results = runSelect<Expense>(
-        'SELECT * FROM expenses WHERE used_at BETWEEN ? AND ? ORDER BY used_at DESC',
-        [start, end]
-      );
-      return NextResponse.json(results);
+      conditions.push('used_at BETWEEN ? AND ?');
+      params.push(start, end);
     }
-    const results = runSelect<Expense>('SELECT * FROM expenses ORDER BY used_at DESC');
+    if (category) {
+      conditions.push('category = ?');
+      params.push(category);
+    }
+    if (conditions.length > 0) {
+      query += ' WHERE ' + conditions.join(' AND ');
+    }
+    query += ' ORDER BY used_at DESC';
+    const results = runSelect<Expense>(query, params);
     return NextResponse.json(results);
   } catch (error) {
     console.error(error);

--- a/tests/api/expense.test.ts
+++ b/tests/api/expense.test.ts
@@ -30,6 +30,27 @@ describe('GET /api/expense', () => {
   });
 });
 
+describe('GET /api/expense with category filter', () => {
+  const catA = 'jest-catA';
+  const catB = 'jest-catB';
+  beforeAll(() => {
+    runExecute('INSERT INTO expenses (category, amount, shop, used_at) VALUES (?, ?, ?, ?)', [catA, 1, 's', '2099-02-01']);
+    runExecute('INSERT INTO expenses (category, amount, shop, used_at) VALUES (?, ?, ?, ?)', [catB, 2, 's', '2099-02-02']);
+  });
+  afterAll(() => {
+    runExecute('DELETE FROM expenses WHERE category IN (?, ?)', [catA, catB]);
+  });
+
+  it('should return only specified category', async () => {
+    const req = new Request(`http://localhost/api/expense?month=2099-02&category=${catA}`);
+    const res = await GET(req as any);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.every((d: any) => d.category === catA)).toBe(true);
+  });
+});
+
 describe('POST /api/expense', () => {
   const entry = { category: 'jest', amount: 123, shop: 'store', used_at: '2099-01-01', used_by: '共有', product_name: 'item', remark: 'memo' };
   afterAll(() => {


### PR DESCRIPTION
## Summary
- allow filtering expenses API by category
- add category selector on expenses page
- test API endpoint for category filter

## Testing
- `npm run lint`
- `npm test` *(fails: Test Suites: 3 failed, 1 passed, 4 total)*

------
https://chatgpt.com/codex/tasks/task_e_688c3f61c70483328c9ef64974c594d4